### PR TITLE
feat: add 'author information' sections to article view

### DIFF
--- a/src/article/ArticleConstants.js
+++ b/src/article/ArticleConstants.js
@@ -1,54 +1,55 @@
-export const MANUSCRIPT_MODE = 'manuscript'
-export const PREVIEW_MODE = 'preview'
-export const METADATA_MODE = 'metadata'
+export const MANUSCRIPT_MODE = 'manuscript';
+export const PREVIEW_MODE = 'preview';
+export const CONTENT_MODE = 'content';
+export const METADATA_MODE = 'metadata';
 
 // Reference Types
-export const JOURNAL_ARTICLE_REF = 'journal-article-ref'
-export const BOOK_REF = 'book-ref'
-export const CHAPTER_REF = 'chapter-ref'
-export const CONFERENCE_PAPER_REF = 'conference-paper-ref'
-export const DATA_PUBLICATION_REF = 'data-publication-ref'
-export const PATENT_REF = 'patent-ref'
-export const ARTICLE_REF = 'article-ref'
-export const NEWSPAPER_ARTICLE_REF = 'newspaper-article-ref'
-export const MAGAZINE_ARTICLE_REF = 'magazine-article-ref'
-export const REPORT_REF = 'report-ref'
-export const SOFTWARE_REF = 'software-ref'
-export const THESIS_REF = 'thesis-ref'
-export const WEBPAGE_REF = 'webpage-ref'
-export const PERIODICAL_REF = 'periodical-ref'
-export const PREPRINT_REF = 'preprint-ref'
+export const JOURNAL_ARTICLE_REF = 'journal-article-ref';
+export const BOOK_REF = 'book-ref';
+export const CHAPTER_REF = 'chapter-ref';
+export const CONFERENCE_PAPER_REF = 'conference-paper-ref';
+export const DATA_PUBLICATION_REF = 'data-publication-ref';
+export const PATENT_REF = 'patent-ref';
+export const ARTICLE_REF = 'article-ref';
+export const NEWSPAPER_ARTICLE_REF = 'newspaper-article-ref';
+export const MAGAZINE_ARTICLE_REF = 'magazine-article-ref';
+export const REPORT_REF = 'report-ref';
+export const SOFTWARE_REF = 'software-ref';
+export const THESIS_REF = 'thesis-ref';
+export const WEBPAGE_REF = 'webpage-ref';
+export const PERIODICAL_REF = 'periodical-ref';
+export const PREPRINT_REF = 'preprint-ref';
 
 export const JATS_BIBR_TYPES_TO_INTERNAL = {
-  'journal': JOURNAL_ARTICLE_REF,
-  'book': BOOK_REF,
-  'confproc': CONFERENCE_PAPER_REF,
-  'data': DATA_PUBLICATION_REF,
-  'patent': PATENT_REF,
-  'report': REPORT_REF,
-  'software': SOFTWARE_REF,
-  'web': WEBPAGE_REF,
+  journal: JOURNAL_ARTICLE_REF,
+  book: BOOK_REF,
+  confproc: CONFERENCE_PAPER_REF,
+  data: DATA_PUBLICATION_REF,
+  patent: PATENT_REF,
+  report: REPORT_REF,
+  software: SOFTWARE_REF,
+  web: WEBPAGE_REF,
   /* TODO: Check the below against the JATS spec. */
-  'chapter': CHAPTER_REF,
-  'article': ARTICLE_REF,
-  'newspaper': NEWSPAPER_ARTICLE_REF,
-  'magazine': MAGAZINE_ARTICLE_REF,
-  'thesis': THESIS_REF,
-  'webpage': WEBPAGE_REF,
+  chapter: CHAPTER_REF,
+  article: ARTICLE_REF,
+  newspaper: NEWSPAPER_ARTICLE_REF,
+  magazine: MAGAZINE_ARTICLE_REF,
+  thesis: THESIS_REF,
+  webpage: WEBPAGE_REF,
   /* eLife specifc mappings */
   'pre-print': PREPRINT_REF,
-  'periodical': PERIODICAL_REF
-}
+  periodical: PERIODICAL_REF
+};
 
 export const INTERNAL_BIBR_TYPES_TO_JATS = Object.keys(JATS_BIBR_TYPES_TO_INTERNAL).reduce((map, jatsType) => {
-  let internalType = JATS_BIBR_TYPES_TO_INTERNAL[jatsType]
-  map[internalType] = jatsType
-  return map
-}, {})
+  let internalType = JATS_BIBR_TYPES_TO_INTERNAL[jatsType];
+  map[internalType] = jatsType;
+  return map;
+}, {});
 
-export const JATS_BIBR_TYPES = Object.keys(JATS_BIBR_TYPES_TO_INTERNAL)
+export const JATS_BIBR_TYPES = Object.keys(JATS_BIBR_TYPES_TO_INTERNAL);
 
-export const INTERNAL_BIBR_TYPES = Object.keys(INTERNAL_BIBR_TYPES_TO_JATS)
+export const INTERNAL_BIBR_TYPES = Object.keys(INTERNAL_BIBR_TYPES_TO_JATS);
 
 export const LICENSES = [
   {
@@ -59,24 +60,78 @@ export const LICENSES = [
     id: 'https://creativecommons.org/licenses/by-sa/2.0/',
     name: 'CC BY-SA 2.0'
   }
-]
+];
 
-export const CARD_MINIMUM_FIELDS = 3
+export const CARD_MINIMUM_FIELDS = 3;
 
 // These are intended to be used for labels (lists, references, etc.)
-export const LATIN_LETTERS_LOWER_CASE = 'abcdefghijklmnopqrstuvwxyz'
-export const LATIN_LETTERS_UPPER_CASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-export const ROMAN_NUMBERS = ['I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX', 'X', 'XI', 'XII', 'XIII', 'XIV', 'XV', 'XVI', 'XVII', 'XVII', 'XIX', 'XX', 'XXI', 'XXII', 'XXIII', 'XXIV', 'XXV', 'XXVI']
-export const ARABIC_NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
+export const LATIN_LETTERS_LOWER_CASE = 'abcdefghijklmnopqrstuvwxyz';
+export const LATIN_LETTERS_UPPER_CASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+export const ROMAN_NUMBERS = [
+  'I',
+  'II',
+  'III',
+  'IV',
+  'V',
+  'VI',
+  'VII',
+  'VIII',
+  'IX',
+  'X',
+  'XI',
+  'XII',
+  'XIII',
+  'XIV',
+  'XV',
+  'XVI',
+  'XVII',
+  'XVII',
+  'XIX',
+  'XX',
+  'XXI',
+  'XXII',
+  'XXIII',
+  'XXIV',
+  'XXV',
+  'XXVI'
+];
+export const ARABIC_NUMBERS = [
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15,
+  16,
+  17,
+  18,
+  19,
+  20,
+  21,
+  22,
+  23,
+  24,
+  25,
+  26
+];
 export const SYMBOLS = ((symbols, times) => {
-  let res = []
+  let res = [];
   for (let n = 1; n <= times; n++) {
     for (let s of symbols) {
-      res.push(new Array(n).fill(s).join(''))
+      res.push(new Array(n).fill(s).join(''));
     }
   }
-  return res
-})(['*', '†', '‡', '¶', '§', '‖', '#'], 4)
+  return res;
+})(['*', '†', '‡', '¶', '§', '‖', '#'], 4);
 
 export const ABSTRACT_TYPES = [
   {
@@ -87,20 +142,23 @@ export const ABSTRACT_TYPES = [
     id: 'web-summary',
     name: 'Web Summary'
   }
-]
+];
 
-export const JATS_GREEN_1_DTD = 'JATS-archivearticle1.dtd'
-export const JATS_GREEN_1_0_PUBLIC_ID = '-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.0 20120330//EN'
-export const JATS_GREEN_1_1_PUBLIC_ID = '-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1 20151215//EN'
-export const JATS_GREEN_1_2_PUBLIC_ID = '-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN'
+export const JATS_GREEN_1_DTD = 'JATS-archivearticle1.dtd';
+export const JATS_GREEN_1_0_PUBLIC_ID =
+  '-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.0 20120330//EN';
+export const JATS_GREEN_1_1_PUBLIC_ID =
+  '-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.1 20151215//EN';
+export const JATS_GREEN_1_2_PUBLIC_ID =
+  '-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN';
 // NOTE: this DTD is used mainly internally so it is not so important how it looks like
-export const TEXTURE_JATS_PUBLIC_ID = '-//TEXTURE/DTD Texture JATS DTD v1.0'
+export const TEXTURE_JATS_PUBLIC_ID = '-//TEXTURE/DTD Texture JATS DTD v1.0';
 // TODO: we should maintain a DTD and bundle with texture or have it in the github repo
-export const TEXTURE_JATS_DTD = 'TextureJATS-1.0.dtd'
+export const TEXTURE_JATS_DTD = 'TextureJATS-1.0.dtd';
 
-const DEFAULT_JATS_SCHEMA_ID = JATS_GREEN_1_2_PUBLIC_ID
-const DEFAULT_JATS_DTD = JATS_GREEN_1_DTD
-export { DEFAULT_JATS_SCHEMA_ID, DEFAULT_JATS_DTD }
+const DEFAULT_JATS_SCHEMA_ID = JATS_GREEN_1_2_PUBLIC_ID;
+const DEFAULT_JATS_DTD = JATS_GREEN_1_DTD;
+export { DEFAULT_JATS_SCHEMA_ID, DEFAULT_JATS_DTD };
 
 // TODO: we need a way to specify which namespaces should be declared
 export const EMPTY_JATS = `<?xml version="1.0" encoding="UTF-8"?>
@@ -119,4 +177,4 @@ export const EMPTY_JATS = `<?xml version="1.0" encoding="UTF-8"?>
   </body>
   <back>
   </back>
-</article>`
+</article>`;

--- a/src/article/components/AuthorDetailsListComponent.js
+++ b/src/article/components/AuthorDetailsListComponent.js
@@ -1,0 +1,111 @@
+import { CustomSurface } from 'substance';
+import { NodeComponent } from '../../kit';
+
+export default class AuthorDetailsListComponent extends CustomSurface {
+  getInitialState() {
+    let items = this._getAuthors();
+    return {
+      hidden: items.length === 0,
+      edit: false
+    };
+  }
+
+  render($$) {
+    let el = $$('div').addClass('sc-author-details-list');
+    el.append(this._renderAuthors($$));
+    return el;
+  }
+
+  _renderAuthors($$) {
+    const authors = this._getAuthors();
+    let els = [];
+    authors.forEach((author, index) => {
+      const authorEl = $$(AuthorDetailsDisplay, { node: author }).ref(author.id);
+      els.push(authorEl);
+    });
+    return els;
+  }
+
+  _getCustomResourceId() {
+    return 'author-details-list';
+  }
+
+  _getAuthors() {
+    return this.props.model.getItems();
+  }
+}
+
+class AuthorDetailsDisplay extends NodeComponent {
+  render($$) {
+    const author = this.props.node;
+    const doc = author.document;
+
+    let el = $$('div').addClass('se-author-details');
+    el.append(
+      $$('p')
+        .addClass('se-author-details-fullname')
+        .append(`${author.givenNames} ${author.surname}${author.corresp ? '*' : ''}`)
+    );
+
+    // Only display an email fir corresponding authors
+    if (author.corresp && author.email) {
+      el.append(
+        $$('p')
+          .addClass('se-author-details-correspondence')
+          .append(`${this.getLabel('author-details-correspendance')}: `)
+          .append(
+            $$('a')
+              .attr('href', `mailto:${author.email}`)
+              .append(author.email)
+          )
+      );
+    }
+
+    // Render affliations in the format, <insitution> <dept> <city> <country>
+    if (author.affiliations.length > 0) {
+      author.affiliations.map(affiliationId => {
+        const affiliationElement = doc.get(affiliationId);
+        if (affiliationElement) {
+          el.append(
+            $$('p')
+              .addClass('se-author-details-affilations')
+              .append(affiliationElement.toString())
+          );
+        }
+      });
+    }
+
+    if (author.contributorIds.length > 0) {
+      author.contributorIds.map(contributorId => {
+        const contributorIdElement = doc.get(contributorId);
+        if (contributorIdElement && contributorIdElement.contribIdType === 'orcid') {
+          // FIXME: Not 100% happy with the below solution, there is likely a better way to do this.
+          const match = /0000-000(1-[5-9]|2-[0-9]|3-[0-4])\d{3}-\d{3}[\dX]/.exec(contributorIdElement.content);
+          if (match) {
+            el.append(
+              $$('p')
+                .addClass('se-author-details-orcid')
+                .append(
+                  $$('a')
+                    .attr('href', match.input)
+                    .append(match[0])
+                )
+            );
+          } else {
+            el.append(
+              $$('p')
+                .addClass('se-author-details-orcid')
+                .append(
+                  $$('a')
+                    .attr('href', contributorIdElement.content)
+                    .append(contributorIdElement.content)
+                )
+            );
+          }
+        }
+      });
+    }
+
+    return el;
+  }
+}

--- a/src/article/components/AuthorDetailsListComponent.js
+++ b/src/article/components/AuthorDetailsListComponent.js
@@ -81,7 +81,7 @@ class AuthorDetailsDisplay extends NodeComponent {
         const contributorIdElement = doc.get(contributorId);
         if (contributorIdElement && contributorIdElement.contribIdType === 'orcid') {
           if (contributorIdElement.authenticated) {
-            orcidIdElement.append($$(FontAwesomeIcon, { icon: 'fa-check-circle' }).addClass('se-icon'));
+            orcidIdElement.append($$(FontAwesomeIcon, { icon: 'fa-circle' }).addClass('se-icon'));
           }
           // FIXME: Not 100% happy with the below solution, there is likely a better way to do this.
           const match = /0000-000(1-[5-9]|2-[0-9]|3-[0-4])\d{3}-\d{3}[\dX]/.exec(contributorIdElement.content);
@@ -111,6 +111,11 @@ class AuthorDetailsDisplay extends NodeComponent {
       });
     }
 
+    el.append(
+      $$('p')
+        .addClass('se-author-details-footnotes')
+        .append('No competing interests declared')
+    );
     return el;
   }
 }

--- a/src/article/components/AuthorDetailsListComponent.js
+++ b/src/article/components/AuthorDetailsListComponent.js
@@ -1,4 +1,4 @@
-import { CustomSurface } from 'substance';
+import { CustomSurface, FontAwesomeIcon } from 'substance';
 import { NodeComponent } from '../../kit';
 
 export default class AuthorDetailsListComponent extends CustomSurface {
@@ -77,12 +77,16 @@ class AuthorDetailsDisplay extends NodeComponent {
 
     if (author.contributorIds.length > 0) {
       author.contributorIds.map(contributorId => {
+        const orcidIdElement = $$('div').addClass('se-author-details-orchid');
         const contributorIdElement = doc.get(contributorId);
         if (contributorIdElement && contributorIdElement.contribIdType === 'orcid') {
+          if (contributorIdElement.authenticated) {
+            orcidIdElement.append($$(FontAwesomeIcon, { icon: 'fa-check-circle' }).addClass('se-icon'));
+          }
           // FIXME: Not 100% happy with the below solution, there is likely a better way to do this.
           const match = /0000-000(1-[5-9]|2-[0-9]|3-[0-4])\d{3}-\d{3}[\dX]/.exec(contributorIdElement.content);
           if (match) {
-            el.append(
+            orcidIdElement.append(
               $$('p')
                 .addClass('se-author-details-orcid')
                 .append(
@@ -92,7 +96,7 @@ class AuthorDetailsDisplay extends NodeComponent {
                 )
             );
           } else {
-            el.append(
+            orcidIdElement.append(
               $$('p')
                 .addClass('se-author-details-orcid')
                 .append(
@@ -103,6 +107,7 @@ class AuthorDetailsDisplay extends NodeComponent {
             );
           }
         }
+        el.append(orcidIdElement);
       });
     }
 

--- a/src/article/components/AuthorDetailsListComponent.js
+++ b/src/article/components/AuthorDetailsListComponent.js
@@ -1,5 +1,7 @@
 import { CustomSurface, FontAwesomeIcon } from 'substance';
 import { NodeComponent } from '../../kit';
+import FootnoteComponent from './FootnoteComponent';
+import { CONTENT_MODE } from '../ArticleConstants';
 
 export default class AuthorDetailsListComponent extends CustomSurface {
   getInitialState() {
@@ -111,11 +113,15 @@ class AuthorDetailsDisplay extends NodeComponent {
       });
     }
 
-    el.append(
-      $$('p')
-        .addClass('se-author-details-footnotes')
-        .append('No competing interests declared')
-    );
+    if (author.competingInterests.length > 0) {
+      author.competingInterests.map(id => {
+        const element = doc.get(id);
+        if (element) {
+          el.append($$(FootnoteComponent, { node: element, mode: CONTENT_MODE }));
+        }
+      });
+    }
+
     return el;
   }
 }

--- a/src/article/components/FootnoteComponent.js
+++ b/src/article/components/FootnoteComponent.js
@@ -1,33 +1,43 @@
-import { NodeComponent } from '../../kit'
-import { getLabel } from '../shared/nodeHelpers'
-import { PREVIEW_MODE } from '../ArticleConstants'
-import PreviewComponent from './PreviewComponent'
+import { NodeComponent } from '../../kit';
+import { getLabel } from '../shared/nodeHelpers';
+import { PREVIEW_MODE, CONTENT_MODE } from '../ArticleConstants';
+import PreviewComponent from './PreviewComponent';
 
 export default class FootnoteComponent extends NodeComponent {
-  render ($$) {
-    const mode = this.props.mode
+  render($$) {
+    const mode = this.props.mode;
     if (mode === PREVIEW_MODE) {
-      return this._renderPreviewVersion($$)
+      return this._renderPreviewVersion($$);
+    } else if (mode == CONTENT_MODE) {
+      return this._renderContentVersion($$);
     }
 
-    const footnote = this.props.node
-    let label = getLabel(footnote) || '?'
+    const footnote = this.props.node;
+    let label = getLabel(footnote) || '?';
 
-    let el = $$('div').addClass('sc-footnote').attr('data-id', footnote.id)
+    let el = $$('div')
+      .addClass('sc-footnote')
+      .attr('data-id', footnote.id);
     el.append(
-      $$('div').addClass('se-container').append(
-        $$('div').addClass('se-label').append(label),
-        this._renderValue($$, 'content', { placeholder: this.getLabel('footnote-placeholder') })
-      )
-    )
-    return el
+      $$('div')
+        .addClass('se-container')
+        .append(
+          $$('div')
+            .addClass('se-label')
+            .append(label),
+          this._renderValue($$, 'content', { placeholder: this.getLabel('footnote-placeholder') })
+        )
+    );
+    return el;
   }
 
-  _renderPreviewVersion ($$) {
-    let footnote = this.props.node
-    let el = $$('div').addClass('sc-footnote').attr('data-id', footnote.id)
+  _renderPreviewVersion($$) {
+    let footnote = this.props.node;
+    let el = $$('div')
+      .addClass('sc-footnote')
+      .attr('data-id', footnote.id);
 
-    let label = getLabel(footnote) || '?'
+    let label = getLabel(footnote) || '?';
     el.append(
       $$(PreviewComponent, {
         id: footnote.id,
@@ -39,7 +49,11 @@ export default class FootnoteComponent extends NodeComponent {
           editable: false
         })
       })
-    )
-    return el
+    );
+    return el;
+  }
+
+  _renderContentVersion($$) {
+    return this._renderValue($$, 'content', { disabled: true, editable: false }).addClass('se-content');
   }
 }

--- a/src/article/components/ManuscriptComponent.js
+++ b/src/article/components/ManuscriptComponent.js
@@ -6,6 +6,7 @@ export default class ManuscriptComponent extends Component {
   render($$) {
     const manuscript = this.props.model;
     const AuthorsListComponent = this.getComponent('authors-list');
+    const AuthorDetailsListComponent = this.getComponent('author-details-list');
     const ReferenceListComponent = this.getComponent('reference-list');
     const RelatedArticlesListComponent = this.getComponent('related-articles-list');
 
@@ -49,8 +50,7 @@ export default class ManuscriptComponent extends Component {
         hideWhenEmpty: true
       }).append(
         $$(AuthorsListComponent, {
-          model: authorsModel,
-          placeholder: this.getLabel('authors-placeholder')
+          model: authorsModel
         }).addClass('sm-authors')
       )
     );
@@ -104,6 +104,21 @@ export default class ManuscriptComponent extends Component {
         $$(ReferenceListComponent, {
           model: referencesModel
         }).addClass('sm-references')
+      )
+    );
+
+    // Author Details
+    let authorDetailsModel = manuscript.getAuthors();
+    el.append(
+      $$(ManuscriptSection, {
+        name: 'author-details',
+        label: this.getLabel('author-details-label'),
+        model: authorDetailsModel,
+        hideWhenEmpty: true
+      }).append(
+        $$(AuthorDetailsListComponent, {
+          model: authorDetailsModel
+        }).addClass('sm-authors')
       )
     );
 

--- a/src/article/components/index.js
+++ b/src/article/components/index.js
@@ -2,6 +2,7 @@ export { default as AbstractComponent } from './AbstractComponent';
 export { default as AcknowledgementComponent } from './AcknowledgementComponent';
 export { default as AddSupplementaryFileWorkflow } from './AddSupplementaryFileWorkflow';
 export { default as AuthorsListComponent } from './AuthorsListComponent';
+export { default as AuthorDetailsListComponent } from './AuthorDetailsListComponent';
 export { default as BlockFormulaComponent } from './BlockFormulaComponent';
 export { default as BlockQuoteComponent } from './BlockQuoteComponent';
 export { default as BoldComponent } from './BoldComponent';

--- a/src/article/converter/jats/ArticleJATSConverters.js
+++ b/src/article/converter/jats/ArticleJATSConverters.js
@@ -4,6 +4,7 @@ import BoxedTextConvertor from './BoxedTextConverter';
 import BlockFormulaConverter from './BlockFormulaConverter';
 import BlockQuoteConverter from './BlockQuoteConverter';
 import BreakConverter from './BreakConverter';
+import ContributorIdentifierConverter from './ContributorIdentifierConverter';
 import FigureConverter from './FigureConverter';
 import FigurePanelConverter from './FigurePanelConverter';
 import FootnoteConverter from './FootnoteConverter';
@@ -41,6 +42,7 @@ export default [
   new BlockFormulaConverter(),
   new BlockQuoteConverter(),
   new BreakConverter(),
+  new ContributorIdentifierConverter(),
   new ExternalLinkConverter(),
   new FigureConverter(),
   new FigurePanelConverter(),

--- a/src/article/converter/jats/ContributorIdentifierConverter.js
+++ b/src/article/converter/jats/ContributorIdentifierConverter.js
@@ -1,0 +1,58 @@
+import { findAllChildren } from '../util/domHelpers';
+import { getLabel } from '../../shared/nodeHelpers';
+
+export default class ContributorIdentifierConverter {
+  get type() {
+    return 'contributor-identifier';
+  }
+
+  get tagName() {
+    return 'contrib-id';
+  }
+
+  import(el, node, importer) {
+    let assigningAuthority = el.attr('assigning-authority');
+    if (assigningAuthority) {
+      node.assigningAuthority = assigningAuthority;
+    }
+    let authenticated = el.attr('authenticated');
+    if (authenticated) {
+      node.authenticated = authenticated === 'true';
+    }
+    let contentType = el.attr('content-type');
+    if (contentType) {
+      node.contentType = contentType;
+    }
+    let contribIdType = el.attr('contrib-id-type');
+    if (contribIdType) {
+      node.contribIdType = contribIdType;
+    }
+    let id = el.attr('id');
+    if (id) {
+      node.id = id;
+    }
+    let specificUse = el.attr('specific-use');
+    if (specificUse) {
+      node.specificUse = specificUse;
+    }
+
+    let content = el.textContent;
+    if (content) {
+      node.content = content;
+    }
+  }
+
+  export(node, el, exporter) {
+    const $$ = exporter.$$;
+    // We gonna need to find another way for node states. I.e. for labels we will have
+    // a hybrid scenario where the labels are either edited manually, and thus we need to record ops,
+    // or they are generated without persisting operations (e.g. think about undo/redo, or collab)
+    // my suggestion would be to introduce volatile ops, they would be excluded from the DocumentChange, that is stored in the change history,
+    // or used for collaborative editing.
+    let label = getLabel(node);
+    if (label) {
+      el.append($$('label').text(label));
+    }
+    el.append(node.resolve('content').map(p => exporter.convertNode(p)));
+  }
+}

--- a/src/article/converter/jats/jats2internal.js
+++ b/src/article/converter/jats/jats2internal.js
@@ -5,6 +5,7 @@ import { RelatedArticle } from '../../nodes';
 
 export default function jats2internal(jats, doc, jatsImporter) {
   // metadata
+  _populateAuthorNotes(doc, jats, jatsImporter);
   _populateAffiliations(doc, jats);
   _populateAuthors(doc, jats, jatsImporter);
   _populateEditors(doc, jats, jatsImporter);
@@ -100,18 +101,37 @@ function _populateContribs(doc, jats, importer, contribsPath, contribEls, groupI
         corresp: contribEl.getAttribute('corresp') === 'yes',
         deceased: contribEl.getAttribute('deceased') === 'yes',
         group: groupId,
-        contributorIds: _getContributorIds(contribEl, importer)
+        contributorIds: _getContributorIds(contribEl, importer),
+        competingInterests: _getAuthorCompetingInterests(contribEl, importer)
       });
       documentHelpers.append(doc, contribsPath, contrib.id);
     }
   }
 }
 
+function _populateAuthorNotes(doc, jats, jatsImporter) {
+  let $$ = jats.createElement.bind(jats);
+  let fnEls = jats.findAll('article > front > article-meta > author-notes > fn');
+  let article = doc.get('article');
+  article.authorNotes = fnEls.map(fnEl => {
+    // there must be at least one paragraph
+    if (!fnEl.find('p')) {
+      fnEl.append($$('p'));
+    }
+    return jatsImporter.convertElement(fnEl).id;
+  });
+}
+
+function _getAuthorCompetingInterests(el, importer) {
+  let xrefs = el.findAll('xref[ref-type=fn]');
+  let ids = xrefs.map(xref => xref.attr('rid'));
+  return ids;
+}
+
 // ATTENTION: bio is not a specific node anymore, just a collection of paragraphs
 function _getBioContent(el, importer) {
   let $$ = el.createElement.bind(el.getOwnerDocument());
   let bioEl = findChild(el, 'bio');
-
   // If there is no bio element we should provide it
   if (!bioEl) {
     bioEl = $$('bio');

--- a/src/article/converter/jats/jats2internal.js
+++ b/src/article/converter/jats/jats2internal.js
@@ -27,18 +27,20 @@ export default function jats2internal(jats, doc, jatsImporter) {
 }
 
 function _populateAffiliations(doc, jats) {
-  const affEls = jats.findAll('article > front > article-meta > aff');
+  // FIXME: At the moment we are ONLY getting affiliations for Authors, so we are missing editors, etc. I think that
+  //        to properly support them all we need to re-model the metadata model.
+  const affEls = jats.findAll('article > front > article-meta > contrib-group[content-type=author] > aff');
   let orgIds = affEls.map(el => {
     let org = {
       id: el.id,
       type: 'affiliation',
-      institution: getText(el, 'institution[content-type=orgname]'),
-      division1: getText(el, 'institution[content-type=orgdiv1]'),
+      institution: getText(el, 'institution[content-type=orgname]') || getText(el, 'institution:not([content-type])'),
+      division1: getText(el, 'institution[content-type=orgdiv1]') || getText(el, 'institution[content-type=dept'),
       division2: getText(el, 'institution[content-type=orgdiv2]'),
       division3: getText(el, 'institution[content-type=orgdiv3]'),
       street: getText(el, 'addr-line[content-type=street-address]'),
       addressComplements: getText(el, 'addr-line[content-type=complements]'),
-      city: getText(el, 'city'),
+      city: getText(el, 'city') || getText(el, 'addr-line > city'),
       state: getText(el, 'state'),
       postalCode: getText(el, 'postal-code'),
       country: getText(el, 'country'),
@@ -139,7 +141,6 @@ function _getAffiliationIds(el, isGroup) {
 
 function _getContributorIds(el, importer) {
   let elements = el.findAll('contrib-id');
-  // NOTE: for groups we need to extract only affiliations of group, without members
   let contributorIds = elements.map(element => importer.convertElement(element).id);
   return contributorIds;
 }

--- a/src/article/converter/jats/jats2internal.js
+++ b/src/article/converter/jats/jats2internal.js
@@ -97,7 +97,8 @@ function _populateContribs(doc, jats, importer, contribsPath, contribEls, groupI
         equalContrib: contribEl.getAttribute('equal-contrib') === 'yes',
         corresp: contribEl.getAttribute('corresp') === 'yes',
         deceased: contribEl.getAttribute('deceased') === 'yes',
-        group: groupId
+        group: groupId,
+        contributorIds: _getContributorIds(contribEl, importer)
       });
       documentHelpers.append(doc, contribsPath, contrib.id);
     }
@@ -134,6 +135,13 @@ function _getAffiliationIds(el, isGroup) {
   }
   let affs = xrefs.map(xref => xref.attr('rid'));
   return affs;
+}
+
+function _getContributorIds(el, importer) {
+  let elements = el.findAll('contrib-id');
+  // NOTE: for groups we need to extract only affiliations of group, without members
+  let contributorIds = elements.map(element => importer.convertElement(element).id);
+  return contributorIds;
 }
 
 function _getAwardIds(el) {

--- a/src/article/nodes/Affiliation.js
+++ b/src/article/nodes/Affiliation.js
@@ -1,27 +1,37 @@
-import { DocumentNode, STRING } from 'substance'
+import { DocumentNode, STRING } from 'substance';
 
 export default class Affiliation extends DocumentNode {
-  toString () {
-    return this.render().join('')
+  toString() {
+    return this.render().join('');
   }
 
-  render (options = {}) {
-    let { institution, division1, division2, division3 } = this
-    let result = institution ? [ institution ] : '???'
+  render(options = {}) {
+    let { institution, division1, division2, division3, city, country } = this;
+    let result = institution ? [institution] : '???';
     // TODO: do we really want this? Because the divisions might
     // be necessary to really understand the displayed name
     if (!options.short && institution) {
       if (division1) {
-        result.push(', ', division1)
+        result.push(', ', division1);
       }
       if (division2) {
-        result.push(', ', division2)
+        result.push(', ', division2);
       }
       if (division3) {
-        result.push(', ', division3)
+        result.push(', ', division3);
+      }
+
+      // FIXME: Rather than the below, should re-architect this function.
+      result.reverse();
+      if (city) {
+        result.push(', ', city);
+      }
+      if (country) {
+        result.push(', ', country);
       }
     }
-    return result
+
+    return result;
   }
 }
 
@@ -42,4 +52,4 @@ Affiliation.schema = {
   fax: STRING,
   email: STRING,
   uri: STRING
-}
+};

--- a/src/article/nodes/ArticleModelPackage.js
+++ b/src/article/nodes/ArticleModelPackage.js
@@ -12,6 +12,7 @@ import BookRef from './BookRef';
 import Break from './Break';
 import ChapterRef from './ChapterRef';
 import ConferencePaperRef from './ConferencePaperRef';
+import ContributorIdentifier from './ContributorIdentifier';
 import CustomAbstract from './CustomAbstract';
 import MetadataField from './MetadataField';
 import DataPublicationRef from './DataPublicationRef';
@@ -82,6 +83,7 @@ export default {
       Break,
       ChapterRef,
       ConferencePaperRef,
+      ContributorIdentifier,
       CustomAbstract,
       MetadataField,
       DataPublicationRef,

--- a/src/article/nodes/ContributorIdentifier.js
+++ b/src/article/nodes/ContributorIdentifier.js
@@ -1,0 +1,14 @@
+import { DocumentNode, STRING, BOOLEAN } from 'substance';
+
+export default class ContributorIdentifier extends DocumentNode {}
+
+ContributorIdentifier.schema = {
+  type: 'contributor-identifier',
+  assigningAuthority: STRING,
+  authenticated: BOOLEAN,
+  contentType: STRING,
+  contribIdType: STRING,
+  id: STRING,
+  specificUse: STRING,
+  content: STRING
+};

--- a/src/article/nodes/Person.js
+++ b/src/article/nodes/Person.js
@@ -1,5 +1,5 @@
-import { DocumentNode, STRING, ONE, MANY, CHILDREN, BOOLEAN } from 'substance'
-import { extractInitials } from './modelHelpers'
+import { DocumentNode, STRING, ONE, MANY, CHILDREN, BOOLEAN } from 'substance';
+import { extractInitials } from './modelHelpers';
 
 export default class Person extends DocumentNode {
   // not used
@@ -7,24 +7,20 @@ export default class Person extends DocumentNode {
   //   return this.render().join('')
   // }
 
-  render (options = {}) {
-    let { prefix, suffix, givenNames, surname } = this
+  render(options = {}) {
+    let { prefix, suffix, givenNames, surname } = this;
     if (options.short) {
-      givenNames = extractInitials(givenNames)
+      givenNames = extractInitials(givenNames);
     }
-    let result = []
+    let result = [];
     if (prefix) {
-      result.push(prefix, ' ')
+      result.push(prefix, ' ');
     }
-    result.push(
-      givenNames,
-      ' ',
-      surname
-    )
+    result.push(givenNames, ' ', surname);
     if (suffix) {
-      result.push(' (', suffix, ')')
+      result.push(' (', suffix, ')');
     }
-    return result
+    return result;
   }
 }
 Person.schema = {
@@ -42,5 +38,6 @@ Person.schema = {
   bio: CHILDREN('paragraph'),
   equalContrib: BOOLEAN,
   corresp: BOOLEAN,
-  deceased: BOOLEAN
-}
+  deceased: BOOLEAN,
+  contributorIds: MANY('contributor-identifier')
+};

--- a/src/article/nodes/Person.js
+++ b/src/article/nodes/Person.js
@@ -1,4 +1,4 @@
-import { DocumentNode, STRING, ONE, MANY, CHILDREN, BOOLEAN } from 'substance';
+import { DocumentNode, STRING, ONE, MANY, CONTAINER, CHILDREN, BOOLEAN } from 'substance';
 import { extractInitials } from './modelHelpers';
 
 export default class Person extends DocumentNode {
@@ -39,5 +39,5 @@ Person.schema = {
   equalContrib: BOOLEAN,
   corresp: BOOLEAN,
   deceased: BOOLEAN,
-  contributorIds: MANY('contributor-identifier')
+  contributorIds: CONTAINER('contributor-identifier')
 };

--- a/src/article/nodes/Person.js
+++ b/src/article/nodes/Person.js
@@ -39,5 +39,6 @@ Person.schema = {
   equalContrib: BOOLEAN,
   corresp: BOOLEAN,
   deceased: BOOLEAN,
-  contributorIds: CONTAINER('contributor-identifier')
+  contributorIds: CONTAINER('contributor-identifier'),
+  competingInterests: CONTAINER('footnote')
 };

--- a/src/article/nodes/index.js
+++ b/src/article/nodes/index.js
@@ -12,6 +12,7 @@ export { default as Box } from './Box';
 export { default as Break } from './Break';
 export { default as ChapterRef } from './ChapterRef';
 export { default as ConferencePaperRef } from './ConferencePaperRef';
+export { default as ContributorIdentifier } from './ContributorIdentifier';
 export { default as CustomAbstract } from './CustomAbstract';
 export { default as MetadataField } from './MetadataField';
 export { default as DataPublicationRef } from './DataPublicationRef';

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -4,6 +4,7 @@ import {
   AbstractComponent,
   AcknowledgementComponent,
   AuthorsListComponent,
+  AuthorDetailsListComponent,
   BlockFormulaComponent,
   BlockQuoteComponent,
   BoldComponent,
@@ -46,6 +47,7 @@ export default {
     config.addComponent('abstract', AbstractComponent);
     config.addComponent('acknowledgement', AcknowledgementComponent);
     config.addComponent('authors-list', AuthorsListComponent);
+    config.addComponent('author-details-list', AuthorDetailsListComponent);
     config.addComponent('bold', BoldComponent);
     config.addComponent('box', BoxComponent);
     config.addComponent('block-formula', BlockFormulaComponent);
@@ -130,5 +132,9 @@ export default {
 
     // Box element labels
     config.addLabel('box-title-label', 'Box text');
+
+    // Author details
+    config.addLabel('author-details-label', 'Author Information');
+    config.addLabel('author-details-correspendance', 'For correspondence');
   }
 };

--- a/src/article/styles/_author-details-list.css
+++ b/src/article/styles/_author-details-list.css
@@ -9,3 +9,17 @@
 .se-author-details-fullname {
   font-weight: var(--t-bold-font-weight);
 }
+
+.se-author-details-orchid {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
+
+.se-author-details-orchid > p {
+  margin-left: var(--t-button-padding);
+}
+
+.se-author-details-orchid > i {
+  color: #a6ce39;
+}

--- a/src/article/styles/_author-details-list.css
+++ b/src/article/styles/_author-details-list.css
@@ -1,0 +1,11 @@
+.se-author-details {
+  margin-top: var(--t-default-spacing);
+}
+
+.se-author-details:first-child {
+  margin-top: var(--t-half-spacing);
+}
+
+.se-author-details-fullname {
+  font-weight: var(--t-bold-font-weight);
+}

--- a/src/article/styles/_index.css
+++ b/src/article/styles/_index.css
@@ -3,6 +3,7 @@
 @import './_add-reference-workflow.css';
 @import './_affiliations-list.css';
 @import './_article-panel.css';
+@import './_author-details-list.css';
 @import './_authors-list.css';
 @import './_block-formula.css';
 @import './_block-formula-editor.css';


### PR DESCRIPTION
Updated the main article view to now display detailed author information as per the UX design document. For this initial implementation, I've cut some corners to get things working as intended, mostly with how the XML is parsed into the document. Having worked through the importing code some more I feel that there is scope for significant improvements to generalise the importing more, however those changes need more consideration and are best saved for another day.

## Summary of changes
- Added support for importing a 'contrib-id' element.
- Added some initial support for 'author-notes' elements, which I import as 'footnotes' as store alongside authors.

## Still to be done
- Contributor IDs are only parsed for 'contrib-groups' with the type 'author', further work will be needed to support other types of group such as 'editors'.
- Edit button is missing from the author detail component.
- No support for exporting a 'contrib-id' elements.
- No support for exporting 'author-note' elements.
- Unit tests need to be created for the new nodes and components.




