### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to Libero
+We encourage contributions of any kind.  By participating in this project, you agree to abide by the [code of conduct](https://libero.pub/code-of-conduct/).
+
+Contributions of code or documentation are covered by our [Contributor License Agreement (CLA)](https://libero.pub/governance/cla/). Please [sign the CLA](https://libero.pub/sign-cla) or make sure your employer has signed the CLA on your behalf. If you have questions about the CLA please email the team at libero@elifesciences.org.
+
+All Libero repositories will have further instructions in their own `CONTRIBUTING.md` file.
+
+# Code Contributions
+The basic steps for code contributions are:
+1. Fork, then clone the repo
+2. Set up your machine and install dependencies
+3. Run all tests and ensure they pass to check your environment is working
+4. Make your change, adding new tests
+5. Run all tests and ensure they pass
+6. Push to your fork and make a pull request
+
+We try to respond to pull requests with an initial comment within 3 working days.
+
+You can help your pull request be accepted by:
+- Writing tests
+- Following the coding standards - (e.g. [PHP coding standards](https://github.com/libero/php-coding-standard))
+- Writing [good commit messages](https://chris.beams.io/posts/git-commit/)
+
+To make a larger contribution, [create an issue on the Libero repo](https://github.com/libero/libero/issues/new/choose) or start a discussion on the [Libero Community Slack](https://libero-community.slack.com/). This helps to get early feedback on design and architecture.
+


### PR DESCRIPTION
## Why

This repo is missing a contributing guide.

## What

Adds the contributing guide to the repo. Copied from the main community contributing guide at https://github.com/libero/community/blob/master/CONTRIBUTING.md.
