### PR TITLE
feat: article information displayed in main article view

### DIFF
--- a/src/article/ArticleConstants.js
+++ b/src/article/ArticleConstants.js
@@ -41,6 +41,29 @@ export const JATS_BIBR_TYPES_TO_INTERNAL = {
   periodical: PERIODICAL_REF,
 };
 
+export const ARTICLE_SUBJECTS = [
+  'Biochemistry and Chemical Biology',
+  'Cancer Biology',
+  'Cell Biology',
+  'Chromosomes and Gene Expression',
+  'Computational and Systems Biology',
+  'Developmental Biology',
+  'Ecology',
+  'Epidemiology and Global Health',
+  'Evolutionary Biology',
+  'Genetics and Genomics',
+  'Human Biology and Medicine',
+  'Immunology and Inflammation',
+  'Microbiology and Infectious Disease',
+  'Neuroscience',
+  'Physics of Living Systems',
+  'Plant Biology',
+  'Stem Cells and Regenerative Medicine',
+  'Structural Biology and Molecular Biophysics',
+];
+
+export const ARTICLE_TYPES = ['Insight', 'Research article', 'Tools and resources', 'Short report', 'Editorial'];
+
 export const INTERNAL_BIBR_TYPES_TO_JATS = Object.keys(JATS_BIBR_TYPES_TO_INTERNAL).reduce((map, jatsType) => {
   let internalType = JATS_BIBR_TYPES_TO_INTERNAL[jatsType];
   map[internalType] = jatsType;

--- a/src/article/ArticlePackage.js
+++ b/src/article/ArticlePackage.js
@@ -134,12 +134,5 @@ export default {
     articleConfig.import(ManuscriptPackage);
 
     articleConfig.import(MetadataPackage);
-
-    // FIXME:
-    // - This is probably a kludge, I don't think this is the right place for this.
-    // - This is duplicated from the MetadataPackage
-    // - Each section of the editor shouldn't need a seperate icon lookup list.
-    config.addIcon('remove', { fontawesome: 'fa-trash' });
-    config.addIcon('delete', { fontawesome: 'fa-times' });
   },
 };

--- a/src/article/ArticlePackage.js
+++ b/src/article/ArticlePackage.js
@@ -140,5 +140,6 @@ export default {
     // - This is duplicated from the MetadataPackage
     // - Each section of the editor shouldn't need a seperate icon lookup list.
     config.addIcon('remove', { fontawesome: 'fa-trash' });
+    config.addIcon('delete', { fontawesome: 'fa-times' });
   },
 };

--- a/src/article/api/ArticleModel.js
+++ b/src/article/api/ArticleModel.js
@@ -57,6 +57,14 @@ export default class ArticleModel extends Model {
     return this._getValueModel('article.title');
   }
 
+  getSubjects() {
+    return this._getValueModel('metadata.subjects');
+  }
+
+  hasSubjects() {
+    return this.getSubjects().length > 0;
+  }
+
   getSubTitle() {
     return this._getValueModel('article.subTitle');
   }

--- a/src/article/api/ArticleModel.js
+++ b/src/article/api/ArticleModel.js
@@ -76,4 +76,26 @@ export default class ArticleModel extends Model {
   getSubTitle() {
     return this._getValueModel('article.subTitle');
   }
+
+  // FIXME: Should consider adding a 'getValue' method, although I don't event think that would be the right way to get
+  //        the value.
+  getDoi() {
+    return this._getValueModel('metadata.doi')._value;
+  }
+
+  getELocationId() {
+    return this._getValueModel('metadata.elocationId')._value;
+  }
+
+  getYear() {
+    return this._getValueModel('metadata.elocationId')._value;
+  }
+
+  getVolume() {
+    return this._getValueModel('metadata.volume')._value;
+  }
+
+  getPublishDate() {
+    return this._getValueModel('metadata.publishedDate')._value;
+  }
 }

--- a/src/article/api/ArticleModel.js
+++ b/src/article/api/ArticleModel.js
@@ -37,6 +37,14 @@ export default class ArticleModel extends Model {
     return this.getFootnotes().length > 0;
   }
 
+  getKeywords() {
+    return this._getValueModel('metadata.keywords');
+  }
+
+  hasKeywords() {
+    return this.getKeywords().length > 0;
+  }
+
   getReferences() {
     return this._getValueModel('article.references');
   }

--- a/src/article/api/ArticleModel.js
+++ b/src/article/api/ArticleModel.js
@@ -91,6 +91,10 @@ export default class ArticleModel extends Model {
     return this._getValueModel('metadata.elocationId')._value;
   }
 
+  getCollectionDate() {
+    return this._getValueModel('metadata.collectionDate')._value;
+  }
+
   getVolume() {
     return this._getValueModel('metadata.volume')._value;
   }

--- a/src/article/components/ArticleInformationComponent.js
+++ b/src/article/components/ArticleInformationComponent.js
@@ -63,45 +63,57 @@ export default class ArticleInformationComponent extends CustomSurface {
       }).addClass('sm-subjects-list'),
     );
 
+    const container = $$('div').addClass('article-information-container');
+
     // Article DOI
     if (articleDoi) {
-      el.append($$(SectionLabel, { label: this.getLabel('article-information-doi-label') }));
-      el.append(
+      const subContainer = $$('div').addClass('article-information-sub-container');
+      subContainer.append($$(SectionLabel, { label: this.getLabel('article-information-doi-label') }));
+      subContainer.append(
         $$('p')
           .addClass('se-article-information-doi')
           .append(articleDoi),
       );
+      container.append(subContainer);
     }
 
     // Article eLocation ID
     if (articleELocationId) {
-      el.append($$(SectionLabel, { label: this.getLabel('article-information-elocation-id-label') }));
-      el.append(
+      const subContainer = $$('div').addClass('article-information-sub-container');
+      subContainer.append($$(SectionLabel, { label: this.getLabel('article-information-elocation-id-label') }));
+      subContainer.append(
         $$('p')
           .addClass('se-article-information-elocation-id')
           .append(articleELocationId),
       );
+      container.append(subContainer);
     }
 
     // Article Year
     if (articleYear) {
-      el.append($$(SectionLabel, { label: this.getLabel('article-information-year-label') }));
-      el.append(
+      const subContainer = $$('div').addClass('article-information-sub-container');
+      subContainer.append($$(SectionLabel, { label: this.getLabel('article-information-year-label') }));
+      subContainer.append(
         $$('p')
           .addClass('se-article-information-year')
           .append(articleYear),
       );
+      container.append(subContainer);
     }
 
     // Article Volume
     if (articleVolume) {
-      el.append($$(SectionLabel, { label: this.getLabel('article-information-volume-label') }));
-      el.append(
+      const subContainer = $$('div').addClass('article-information-sub-container');
+      subContainer.append($$(SectionLabel, { label: this.getLabel('article-information-volume-label') }));
+      subContainer.append(
         $$('p')
           .addClass('se-article-information-volume')
           .append(articleVolume),
       );
+      container.append(subContainer);
     }
+
+    el.append(container);
 
     // Publish Date
     if (articlePublishDate) {
@@ -112,6 +124,7 @@ export default class ArticleInformationComponent extends CustomSurface {
           .append(articlePublishDate),
       );
     }
+
     return el;
   }
 

--- a/src/article/components/ArticleInformationComponent.js
+++ b/src/article/components/ArticleInformationComponent.js
@@ -19,6 +19,10 @@ export default class ArticleInformationComponent extends CustomSurface {
     // Models
     const subjectsModel = this.props.model.getSubjects();
     const keywordsModel = this.props.model.getKeywords();
+    const articleDoi = this.props.model.getDoi();
+    const articleELocationId = this.props.model.getELocationId();
+    const articleVolume = this.props.model.getVolume();
+    const articlePublishDate = this.props.model.getPublishDate();
 
     // Subjects
     el.append($$(SectionLabel, { label: this.getLabel('article-information-subjects-label') }));
@@ -58,6 +62,45 @@ export default class ArticleInformationComponent extends CustomSurface {
       }).addClass('sm-subjects-list'),
     );
 
+    // Article DOI
+    if (articleDoi) {
+      el.append($$(SectionLabel, { label: this.getLabel('article-information-doi-label') }));
+      el.append(
+        $$('p')
+          .addClass('se-article-information-doi')
+          .append(articleDoi),
+      );
+    }
+
+    // Article eLocation ID
+    if (articleELocationId) {
+      el.append($$(SectionLabel, { label: this.getLabel('article-information-elocation-id-label') }));
+      el.append(
+        $$('p')
+          .addClass('se-article-information-elocation-id')
+          .append(articleELocationId),
+      );
+    }
+
+    // Article Volume
+    if (articleVolume) {
+      el.append($$(SectionLabel, { label: this.getLabel('article-information-volume-label') }));
+      el.append(
+        $$('p')
+          .addClass('se-article-information-volume')
+          .append(articleVolume),
+      );
+    }
+
+    // Publish Date
+    if (articlePublishDate) {
+      el.append($$(SectionLabel, { label: this.getLabel('article-information-publish-date-label') }));
+      el.append(
+        $$('p')
+          .addClass('se-article-information-publish-date')
+          .append(articlePublishDate),
+      );
+    }
     return el;
   }
 

--- a/src/article/components/ArticleInformationComponent.js
+++ b/src/article/components/ArticleInformationComponent.js
@@ -12,11 +12,13 @@ export default class ArticleInformationComponent extends CustomSurface {
     const el = $$('div').addClass('sc-article-information');
 
     // Components
+    const KeywordsListComponent = this.getComponent('keywords-list');
     const SubjectsListComponent = this.getComponent('subjects-list');
     const SectionLabel = this.getComponent('section-label');
 
     // Models
     const subjectsModel = this.props.model.getSubjects();
+    const keywordsModel = this.props.model.getKeywords();
 
     // Subjects
     el.append($$(SectionLabel, { label: this.getLabel('article-information-subjects-label') }));
@@ -27,9 +29,25 @@ export default class ArticleInformationComponent extends CustomSurface {
       }).addClass('sm-subjects-list'),
     );
 
-    // Keywords By Group
+    // FIXME: This code be changed to get all keywords, sort by group then render each group.
 
-    // Research Organisms
+    // Keywords By Author
+    el.append($$(SectionLabel, { label: this.getLabel('author-generated') }));
+    el.append(
+      $$(KeywordsListComponent, {
+        model: keywordsModel,
+        type: 'author-generated',
+      }).addClass('sm-keywords-list'),
+    );
+
+    // Keywords Research Organisms
+    el.append($$(SectionLabel, { label: this.getLabel('research-organism') }));
+    el.append(
+      $$(KeywordsListComponent, {
+        model: keywordsModel,
+        type: 'research-organism',
+      }).addClass('sm-keywords-list'),
+    );
 
     // Article Type
     el.append($$(SectionLabel, { label: this.getLabel('article-information-type-label') }));

--- a/src/article/components/ArticleInformationComponent.js
+++ b/src/article/components/ArticleInformationComponent.js
@@ -1,7 +1,4 @@
 import { CustomSurface, FontAwesomeIcon } from 'substance';
-import { NodeComponent } from '../../kit';
-import FootnoteComponent from './FootnoteComponent';
-import { CONTENT_MODE } from '../ArticleConstants';
 
 export default class ArticleInformationComponent extends CustomSurface {
   getInitialState() {
@@ -13,7 +10,36 @@ export default class ArticleInformationComponent extends CustomSurface {
 
   render($$) {
     const el = $$('div').addClass('sc-article-information');
-    el.append($$('div').append('Hello World!'));
+
+    // Components
+    const SubjectsListComponent = this.getComponent('subjects-list');
+    const SectionLabel = this.getComponent('section-label');
+
+    // Models
+    const subjectsModel = this.props.model.getSubjects();
+
+    // Subjects
+    el.append($$(SectionLabel, { label: this.getLabel('article-information-subjects-label') }));
+    el.append(
+      $$(SubjectsListComponent, {
+        model: subjectsModel,
+        type: 'subject',
+      }).addClass('sm-subjects-list'),
+    );
+
+    // Keywords By Group
+
+    // Research Organisms
+
+    // Article Type
+    el.append($$(SectionLabel, { label: this.getLabel('article-information-type-label') }));
+    el.append(
+      $$(SubjectsListComponent, {
+        model: subjectsModel,
+        type: 'heading',
+      }).addClass('sm-subjects-list'),
+    );
+
     return el;
   }
 

--- a/src/article/components/ArticleInformationComponent.js
+++ b/src/article/components/ArticleInformationComponent.js
@@ -23,6 +23,7 @@ export default class ArticleInformationComponent extends CustomSurface {
     const articleELocationId = this.props.model.getELocationId();
     const articleVolume = this.props.model.getVolume();
     const articlePublishDate = this.props.model.getPublishDate();
+    const articleYear = this.props.model.getCollectionDate();
 
     // Subjects
     el.append($$(SectionLabel, { label: this.getLabel('article-information-subjects-label') }));
@@ -82,6 +83,16 @@ export default class ArticleInformationComponent extends CustomSurface {
       );
     }
 
+    // Article Year
+    if (articleYear) {
+      el.append($$(SectionLabel, { label: this.getLabel('article-information-year-label') }));
+      el.append(
+        $$('p')
+          .addClass('se-article-information-year')
+          .append(articleYear),
+      );
+    }
+
     // Article Volume
     if (articleVolume) {
       el.append($$(SectionLabel, { label: this.getLabel('article-information-volume-label') }));
@@ -118,92 +129,3 @@ export default class ArticleInformationComponent extends CustomSurface {
     return 'article-information';
   }
 }
-
-// class AuthorDetailsDisplay extends NodeComponent {
-//   render($$) {
-//     const author = this.props.node;
-//     const doc = author.document;
-
-//     let el = $$('div').addClass('se-author-details');
-//     el.append(
-//       $$('p')
-//         .addClass('se-author-details-fullname')
-//         .append(`${author.givenNames} ${author.surname}`),
-//     );
-
-//     // Only display an email fir corresponding authors
-//     if (author.email) {
-//       el.append(
-//         $$('p')
-//           .addClass('se-author-details-correspondence')
-//           .append(author.corresp ? `${this.getLabel('author-details-correspendance')}: ` : '')
-//           .append(
-//             $$('a')
-//               .attr('href', `mailto:${author.email}`)
-//               .append(author.email),
-//           ),
-//       );
-//     }
-
-//     // Render affliations in the format, <insitution> <dept> <city> <country>
-//     if (author.affiliations.length > 0) {
-//       author.affiliations.map(affiliationId => {
-//         const affiliationElement = doc.get(affiliationId);
-//         if (affiliationElement) {
-//           el.append(
-//             $$('p')
-//               .addClass('se-author-details-affilations')
-//               .append(affiliationElement.toString()),
-//           );
-//         }
-//       });
-//     }
-
-//     if (author.contributorIds.length > 0) {
-//       author.contributorIds.map(contributorId => {
-//         const orcidIdElement = $$('div').addClass('se-author-details-orchid');
-//         const contributorIdElement = doc.get(contributorId);
-//         if (contributorIdElement && contributorIdElement.contribIdType === 'orcid') {
-//           if (contributorIdElement.authenticated) {
-//             orcidIdElement.append($$(FontAwesomeIcon, { icon: 'fa-circle' }).addClass('se-icon'));
-//           }
-//           // FIXME: Not 100% happy with the below solution, there is likely a better way to do this.
-//           const match = /0000-000(1-[5-9]|2-[0-9]|3-[0-4])\d{3}-\d{3}[\dX]/.exec(contributorIdElement.content);
-//           if (match) {
-//             orcidIdElement.append(
-//               $$('p')
-//                 .addClass('se-author-details-orcid')
-//                 .append(
-//                   $$('a')
-//                     .attr('href', match.input)
-//                     .append(match[0]),
-//                 ),
-//             );
-//           } else {
-//             orcidIdElement.append(
-//               $$('p')
-//                 .addClass('se-author-details-orcid')
-//                 .append(
-//                   $$('a')
-//                     .attr('href', contributorIdElement.content)
-//                     .append(contributorIdElement.content),
-//                 ),
-//             );
-//           }
-//         }
-//         el.append(orcidIdElement);
-//       });
-//     }
-
-//     if (author.competingInterests.length > 0) {
-//       author.competingInterests.map(id => {
-//         const element = doc.get(id);
-//         if (element) {
-//           el.append($$(FootnoteComponent, { node: element, mode: CONTENT_MODE }));
-//         }
-//       });
-//     }
-
-//     return el;
-//   }
-// }

--- a/src/article/components/ArticleInformationComponent.js
+++ b/src/article/components/ArticleInformationComponent.js
@@ -1,0 +1,122 @@
+import { CustomSurface, FontAwesomeIcon } from 'substance';
+import { NodeComponent } from '../../kit';
+import FootnoteComponent from './FootnoteComponent';
+import { CONTENT_MODE } from '../ArticleConstants';
+
+export default class ArticleInformationComponent extends CustomSurface {
+  getInitialState() {
+    return {
+      hidden: false,
+      edit: false, // TODO: Check if this effects children of the control or not!
+    };
+  }
+
+  render($$) {
+    const el = $$('div').addClass('sc-article-information');
+    el.append($$('div').append('Hello World!'));
+    return el;
+  }
+
+  _renderAuthors($$) {
+    const authors = this._getAuthors();
+    const els = [];
+    authors.forEach((author, index) => {
+      const authorEl = $$(AuthorDetailsDisplay, { node: author }).ref(author.id);
+      els.push(authorEl);
+    });
+    return els;
+  }
+
+  _getCustomResourceId() {
+    return 'article-information';
+  }
+}
+
+// class AuthorDetailsDisplay extends NodeComponent {
+//   render($$) {
+//     const author = this.props.node;
+//     const doc = author.document;
+
+//     let el = $$('div').addClass('se-author-details');
+//     el.append(
+//       $$('p')
+//         .addClass('se-author-details-fullname')
+//         .append(`${author.givenNames} ${author.surname}`),
+//     );
+
+//     // Only display an email fir corresponding authors
+//     if (author.email) {
+//       el.append(
+//         $$('p')
+//           .addClass('se-author-details-correspondence')
+//           .append(author.corresp ? `${this.getLabel('author-details-correspendance')}: ` : '')
+//           .append(
+//             $$('a')
+//               .attr('href', `mailto:${author.email}`)
+//               .append(author.email),
+//           ),
+//       );
+//     }
+
+//     // Render affliations in the format, <insitution> <dept> <city> <country>
+//     if (author.affiliations.length > 0) {
+//       author.affiliations.map(affiliationId => {
+//         const affiliationElement = doc.get(affiliationId);
+//         if (affiliationElement) {
+//           el.append(
+//             $$('p')
+//               .addClass('se-author-details-affilations')
+//               .append(affiliationElement.toString()),
+//           );
+//         }
+//       });
+//     }
+
+//     if (author.contributorIds.length > 0) {
+//       author.contributorIds.map(contributorId => {
+//         const orcidIdElement = $$('div').addClass('se-author-details-orchid');
+//         const contributorIdElement = doc.get(contributorId);
+//         if (contributorIdElement && contributorIdElement.contribIdType === 'orcid') {
+//           if (contributorIdElement.authenticated) {
+//             orcidIdElement.append($$(FontAwesomeIcon, { icon: 'fa-circle' }).addClass('se-icon'));
+//           }
+//           // FIXME: Not 100% happy with the below solution, there is likely a better way to do this.
+//           const match = /0000-000(1-[5-9]|2-[0-9]|3-[0-4])\d{3}-\d{3}[\dX]/.exec(contributorIdElement.content);
+//           if (match) {
+//             orcidIdElement.append(
+//               $$('p')
+//                 .addClass('se-author-details-orcid')
+//                 .append(
+//                   $$('a')
+//                     .attr('href', match.input)
+//                     .append(match[0]),
+//                 ),
+//             );
+//           } else {
+//             orcidIdElement.append(
+//               $$('p')
+//                 .addClass('se-author-details-orcid')
+//                 .append(
+//                   $$('a')
+//                     .attr('href', contributorIdElement.content)
+//                     .append(contributorIdElement.content),
+//                 ),
+//             );
+//           }
+//         }
+//         el.append(orcidIdElement);
+//       });
+//     }
+
+//     if (author.competingInterests.length > 0) {
+//       author.competingInterests.map(id => {
+//         const element = doc.get(id);
+//         if (element) {
+//           el.append($$(FootnoteComponent, { node: element, mode: CONTENT_MODE }));
+//         }
+//       });
+//     }
+
+//     return el;
+//   }
+// }

--- a/src/article/components/AuthorDetailsListComponent.js
+++ b/src/article/components/AuthorDetailsListComponent.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import { CustomSurface, FontAwesomeIcon } from 'substance';
 import { NodeComponent } from '../../kit';
 import FootnoteComponent from './FootnoteComponent';
@@ -5,7 +6,7 @@ import { CONTENT_MODE } from '../ArticleConstants';
 
 export default class AuthorDetailsListComponent extends CustomSurface {
   getInitialState() {
-    let items = this._getAuthors();
+    const items = this._getAuthors();
     return {
       hidden: items.length === 0,
       edit: false,
@@ -13,14 +14,14 @@ export default class AuthorDetailsListComponent extends CustomSurface {
   }
 
   render($$) {
-    let el = $$('div').addClass('sc-author-details-list');
+    const el = $$('div').addClass('sc-author-details-list');
     el.append(this._renderAuthors($$));
     return el;
   }
 
   _renderAuthors($$) {
     const authors = this._getAuthors();
-    let els = [];
+    const els = [];
     authors.forEach((author, index) => {
       const authorEl = $$(AuthorDetailsDisplay, { node: author }).ref(author.id);
       els.push(authorEl);
@@ -42,7 +43,7 @@ class AuthorDetailsDisplay extends NodeComponent {
     const author = this.props.node;
     const doc = author.document;
 
-    let el = $$('div').addClass('se-author-details');
+    const el = $$('div').addClass('se-author-details');
     el.append(
       $$('p')
         .addClass('se-author-details-fullname')

--- a/src/article/components/BoxComponent.js
+++ b/src/article/components/BoxComponent.js
@@ -2,17 +2,17 @@ import { NodeComponent } from '../../kit';
 
 export default class BoxComponent extends NodeComponent {
   render($$) {
-    let node = this.props.node;
+    const node = this.props.node;
 
     const Button = this.getComponent('button');
     const SectionLabel = this.getComponent('section-label');
 
     // Card
-    let el = $$('div')
+    const el = $$('div')
       .addClass('sc-box')
       .attr('data-id', node.id);
 
-    let titleEl = $$('div').addClass('sc-title');
+    const titleEl = $$('div').addClass('sc-title');
 
     // Label
     titleEl.append($$(SectionLabel, { label: 'box-title-label' }));
@@ -20,7 +20,7 @@ export default class BoxComponent extends NodeComponent {
     // Remove Button
     titleEl.append(
       $$(Button, {
-        icon: 'remove',
+        icon: 'trash',
       })
         .addClass('se-remove-value')
         .on('click', this._onRemove),

--- a/src/article/components/KeywordComponent.js
+++ b/src/article/components/KeywordComponent.js
@@ -1,0 +1,36 @@
+import { NodeComponent } from '../../kit';
+import { getLabel } from '../shared/nodeHelpers';
+
+export default class KeywordComponent extends NodeComponent {
+  render($$) {
+    const keyword = this.props.node;
+    const selected = this.props.selected;
+    const Button = this.getComponent('button');
+    //const label = getLabel(footnote) || '?';
+
+    const el = $$('div')
+      .addClass('sc-keyword')
+      .attr('data-id', keyword.id);
+
+    el.append(
+      this._renderValue($$, 'name', { placeholder: this.getLabel('footnote-placeholder'), disabled: !selected }),
+    );
+
+    if (!selected) {
+      el.addClass('sc-keyword-border');
+      el.append(
+        $$(Button, {
+          icon: 'delete',
+        })
+          .addClass('se-remove-value')
+          .on('click', this._onRemove),
+      );
+    }
+
+    return el;
+  }
+
+  _onRemove() {
+    this.send('removeKeyword', this.props.node);
+  }
+}

--- a/src/article/components/KeywordsListComponent.js
+++ b/src/article/components/KeywordsListComponent.js
@@ -2,6 +2,7 @@
 import { CustomSurface } from 'substance';
 import { NodeComponent } from '../../kit';
 import { getLabel } from '../shared/nodeHelpers';
+import KeywordComponent from './KeywordComponent';
 
 export default class KeywordsListComponent extends CustomSurface {
   getInitialState() {
@@ -38,8 +39,10 @@ export default class KeywordsListComponent extends CustomSurface {
     const keywords = this._getKeywords(this.props.type);
     const els = [];
     keywords.forEach(keyword => {
-      const keywordElement = $$(KeywordDisplay, { node: keyword }).ref(keyword.id);
-      if (sel && sel.nodeId === keyword.id) {
+      const selected = sel && sel.path && sel.path[0] === keyword.id ? true : false;
+      const keywordElement = $$(KeywordComponent, { node: keyword, selected }).ref(keyword.id);
+      // TODO: This should be handled maybe in the sub component
+      if (selected) {
         keywordElement.addClass('sm-selected');
       }
       els.push(keywordElement);

--- a/src/article/components/KeywordsListComponent.js
+++ b/src/article/components/KeywordsListComponent.js
@@ -5,6 +5,12 @@ import { getLabel } from '../shared/nodeHelpers';
 import KeywordComponent from './KeywordComponent';
 
 export default class KeywordsListComponent extends CustomSurface {
+  getActionHandlers() {
+    return {
+      removeKeyword: this._removeKeyword,
+    };
+  }
+
   getInitialState() {
     const items = this._getKeywords();
     return {
@@ -62,31 +68,8 @@ export default class KeywordsListComponent extends CustomSurface {
     }
     return keywords;
   }
-}
 
-class KeywordDisplay extends NodeComponent {
-  render($$) {
-    const keyword = this.props.node;
-    // FIXME: Need a better CSS class here
-    const el = $$('span').addClass('se-contrib');
-    el.append(this.context.api.renderEntity(keyword));
-    el.on('mousedown', this._onMousedown).on('click', this._onClick);
-    return el;
-  }
-
-  _onMousedown(e) {
-    e.stopPropagation();
-    if (e.button === 2) {
-      this._select();
-    }
-  }
-
-  _onClick(e) {
-    e.stopPropagation();
-    this._select();
-  }
-
-  _select() {
-    this.context.api.selectEntity(this.props.node.id);
+  _removeKeyword(keyword) {
+    this.props.model.removeItem(keyword);
   }
 }

--- a/src/article/components/KeywordsListComponent.js
+++ b/src/article/components/KeywordsListComponent.js
@@ -1,0 +1,89 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import { CustomSurface } from 'substance';
+import { NodeComponent } from '../../kit';
+import { getLabel } from '../shared/nodeHelpers';
+
+export default class KeywordsListComponent extends CustomSurface {
+  getInitialState() {
+    const items = this._getKeywords();
+    return {
+      hidden: items.length === 0,
+      edit: false,
+    };
+  }
+
+  didMount() {
+    super.didMount();
+
+    const appState = this.context.editorState;
+    // FIXME: it is not good to rerender on every selection change.
+    // Instead it should derive a state from the selection, and only rerender if the
+    // state has changed (not-selected, selected + author id)
+    appState.addObserver(['selection'], this.rerender, this, { stage: 'render' });
+  }
+
+  dispose() {
+    super.dispose();
+    this.context.editorState.removeObserver(this);
+  }
+
+  render($$) {
+    const el = $$('div').addClass('sc-keywords-list');
+    el.append(this._renderKeywords($$));
+    return el;
+  }
+
+  _renderKeywords($$) {
+    const sel = this.context.editorState.selection;
+    const keywords = this._getKeywords(this.props.type);
+    const els = [];
+    keywords.forEach(keyword => {
+      const keywordElement = $$(KeywordDisplay, { node: keyword }).ref(keyword.id);
+      if (sel && sel.nodeId === keyword.id) {
+        keywordElement.addClass('sm-selected');
+      }
+      els.push(keywordElement);
+    });
+    return els;
+  }
+
+  _getCustomResourceId() {
+    // FIXME: This seems like a hack to me, need to take a deeper look at this.
+    return 'subjects-list-' + (this.props.type || 'default');
+  }
+
+  _getKeywords(type) {
+    let keywords = this.props.model.getItems();
+    if (type) {
+      keywords = keywords.filter(keyword => keyword.groupType === type);
+    }
+    return keywords;
+  }
+}
+
+class KeywordDisplay extends NodeComponent {
+  render($$) {
+    const keyword = this.props.node;
+    // FIXME: Need a better CSS class here
+    const el = $$('span').addClass('se-contrib');
+    el.append(this.context.api.renderEntity(keyword));
+    el.on('mousedown', this._onMousedown).on('click', this._onClick);
+    return el;
+  }
+
+  _onMousedown(e) {
+    e.stopPropagation();
+    if (e.button === 2) {
+      this._select();
+    }
+  }
+
+  _onClick(e) {
+    e.stopPropagation();
+    this._select();
+  }
+
+  _select() {
+    this.context.api.selectEntity(this.props.node.id);
+  }
+}

--- a/src/article/components/ManuscriptComponent.js
+++ b/src/article/components/ManuscriptComponent.js
@@ -10,13 +10,14 @@ export default class ManuscriptComponent extends Component {
     const AuthorDetailsListComponent = this.getComponent('author-details-list');
     const ReferenceListComponent = this.getComponent('reference-list');
     const RelatedArticlesListComponent = this.getComponent('related-articles-list');
+    const SubjectsListComponent = this.getComponent('subjects-list');
 
-    let el = $$('div').addClass('sc-manuscript');
+    const el = $$('div').addClass('sc-manuscript');
 
     // TODO: maybe we want to be able to configure if a section should be hidden when empty
 
     // Title
-    let titleModel = manuscript.getTitle();
+    const titleModel = manuscript.getTitle();
     el.append(
       $$(ManuscriptSection, {
         name: 'title',
@@ -28,8 +29,9 @@ export default class ManuscriptComponent extends Component {
         }).addClass('sm-title'),
       ),
     );
+
     // Sub-title
-    let subTitleModel = manuscript.getSubTitle();
+    const subTitleModel = manuscript.getSubTitle();
     el.append(
       $$(ManuscriptSection, {
         name: 'subtitle',
@@ -41,8 +43,9 @@ export default class ManuscriptComponent extends Component {
         }).addClass('sm-subtitle'),
       ),
     );
+
     // Authors
-    let authorsModel = manuscript.getAuthors();
+    const authorsModel = manuscript.getAuthors();
     el.append(
       $$(ManuscriptSection, {
         name: 'authors',
@@ -57,7 +60,7 @@ export default class ManuscriptComponent extends Component {
     );
 
     // Affiliations
-    let affiliationsModel = manuscript.getAffiliations();
+    const affiliationsModel = manuscript.getAffiliations();
     el.append(
       $$(ManuscriptSection, {
         name: 'affiliations',
@@ -72,7 +75,7 @@ export default class ManuscriptComponent extends Component {
     );
 
     // Abstract
-    let abstractModel = manuscript.getAbstract();
+    const abstractModel = manuscript.getAbstract();
     el.append(
       $$(ManuscriptSection, {
         name: 'abstract',
@@ -85,8 +88,9 @@ export default class ManuscriptComponent extends Component {
         }).addClass('sm-abstract'),
       ),
     );
+
     // Body
-    let bodyModel = manuscript.getBody();
+    const bodyModel = manuscript.getBody();
     el.append(
       $$(ManuscriptSection, {
         name: 'body',
@@ -99,8 +103,9 @@ export default class ManuscriptComponent extends Component {
         }).addClass('sm-body'),
       ),
     );
+
     // Footnotes
-    let footnotesModel = manuscript.getFootnotes();
+    const footnotesModel = manuscript.getFootnotes();
     el.append(
       $$(ManuscriptSection, {
         name: 'footnotes',
@@ -111,7 +116,7 @@ export default class ManuscriptComponent extends Component {
     );
 
     // Acknowledgements
-    let acknowledgementsModel = manuscript.getAcknowledgements();
+    const acknowledgementsModel = manuscript.getAcknowledgements();
     el.append(
       $$(ManuscriptSection, {
         name: 'acknowledgements',
@@ -127,7 +132,7 @@ export default class ManuscriptComponent extends Component {
     );
 
     // References
-    let referencesModel = manuscript.getReferences();
+    const referencesModel = manuscript.getReferences();
     el.append(
       $$(ManuscriptSection, {
         name: 'references',
@@ -142,7 +147,7 @@ export default class ManuscriptComponent extends Component {
     );
 
     // Author Details
-    let authorDetailsModel = manuscript.getAuthors();
+    const authorDetailsModel = manuscript.getAuthors();
     el.append(
       $$(ManuscriptSection, {
         name: 'author-details',
@@ -156,8 +161,24 @@ export default class ManuscriptComponent extends Component {
       ),
     );
 
+    // Article Information
+    const subjectsModel = manuscript.getSubjects();
+    el.append(
+      $$(ManuscriptSection, {
+        name: 'article-information',
+        label: this.getLabel('article-information-label'),
+        model: subjectsModel,
+        hideWhenEmpty: false,
+      }).append(
+        $$(SubjectsListComponent, {
+          model: subjectsModel,
+          type: 'subject',
+        }).addClass('sm-subjects-list'),
+      ),
+    );
+
     // Related Articles
-    let relatedArticlesModel = manuscript.getRelatedArticles();
+    const relatedArticlesModel = manuscript.getRelatedArticles();
     el.append(
       $$(ManuscriptSection, {
         name: 'related-articles',

--- a/src/article/components/ManuscriptComponent.js
+++ b/src/article/components/ManuscriptComponent.js
@@ -5,12 +5,16 @@ import ManuscriptSection from './ManuscriptSection';
 export default class ManuscriptComponent extends Component {
   render($$) {
     const manuscript = this.props.model;
+
+    // TODO: Need to understand why in some places they 'lookup' the components and assign them to variables, vs just a
+    //       simple import. Assume there is some method to - what seems to me - madness in doing things different ways.
     const AffiliationsListComponent = this.getComponent('affiliations-list');
+    const ArticleInformationComponent = this.getComponent('article-information');
     const AuthorsListComponent = this.getComponent('authors-list');
     const AuthorDetailsListComponent = this.getComponent('author-details-list');
     const ReferenceListComponent = this.getComponent('reference-list');
     const RelatedArticlesListComponent = this.getComponent('related-articles-list');
-    const SubjectsListComponent = this.getComponent('subjects-list');
+    //const SubjectsListComponent = this.getComponent('subjects-list');
 
     const el = $$('div').addClass('sc-manuscript');
 
@@ -168,59 +172,72 @@ export default class ManuscriptComponent extends Component {
         label: this.getLabel('article-information-label'),
         model: [],
         hideWhenEmpty: false,
-      }),
-    );
-
-    // Subjects
-    const subjectsModel = manuscript.getSubjects();
-    el.append(
-      $$(ManuscriptSection, {
-        name: 'article-information-subjects',
-        label: this.getLabel('article-information-subjects-label'),
-        model: subjectsModel,
-        hideWhenEmpty: false,
       }).append(
-        $$(SubjectsListComponent, {
-          model: subjectsModel,
-          type: 'subject',
-        }).addClass('sm-subjects-list'),
+        $$(ArticleInformationComponent, {
+          model: [],
+        }),
       ),
     );
 
-    // Keywords
-    el.append(
-      $$(ManuscriptSection, {
-        name: 'article-information-keywords',
-        label: this.getLabel('article-information-keywords-label'),
-        model: [],
-        hideWhenEmpty: false,
-      }),
-    );
+    // el.append(
+    //   $$(ManuscriptSection, {
+    //     name: 'article-information',
+    //     label: this.getLabel('article-information-label'),
+    //     model: [],
+    //     hideWhenEmpty: false,
+    //   }),
+    // );
 
-    // Research Organisms
-    el.append(
-      $$(ManuscriptSection, {
-        name: 'article-information-research-organisms',
-        label: this.getLabel('article-information-research-organisms-label'),
-        model: [],
-        hideWhenEmpty: false,
-      }),
-    );
+    // // Subjects
+    // const subjectsModel = manuscript.getSubjects();
+    // el.append(
+    //   $$(ManuscriptSection, {
+    //     name: 'article-information-subjects',
+    //     label: this.getLabel('article-information-subjects-label'),
+    //     model: subjectsModel,
+    //     hideWhenEmpty: false,
+    //   }).append(
+    //     $$(SubjectsListComponent, {
+    //       model: subjectsModel,
+    //       type: 'subject',
+    //     }).addClass('sm-subjects-list'),
+    //   ),
+    // );
 
-    // Article Type
-    el.append(
-      $$(ManuscriptSection, {
-        name: 'article-information-type',
-        label: this.getLabel('article-information-type-label'),
-        model: subjectsModel,
-        hideWhenEmpty: false,
-      }).append(
-        $$(SubjectsListComponent, {
-          model: subjectsModel,
-          type: 'heading',
-        }).addClass('sm-subjects-list'),
-      ),
-    );
+    // // Keywords
+    // el.append(
+    //   $$(ManuscriptSection, {
+    //     name: 'article-information-keywords',
+    //     label: this.getLabel('article-information-keywords-label'),
+    //     model: [],
+    //     hideWhenEmpty: false,
+    //   }),
+    // );
+
+    // // Research Organisms
+    // el.append(
+    //   $$(ManuscriptSection, {
+    //     name: 'article-information-research-organisms',
+    //     label: this.getLabel('article-information-research-organisms-label'),
+    //     model: [],
+    //     hideWhenEmpty: false,
+    //   }),
+    // );
+
+    // // Article Type
+    // el.append(
+    //   $$(ManuscriptSection, {
+    //     name: 'article-information-type',
+    //     label: this.getLabel('article-information-type-label'),
+    //     model: subjectsModel,
+    //     hideWhenEmpty: false,
+    //   }).append(
+    //     $$(SubjectsListComponent, {
+    //       model: subjectsModel,
+    //       type: 'heading',
+    //     }).addClass('sm-subjects-list'),
+    //   ),
+    // );
 
     // Related Articles
     const relatedArticlesModel = manuscript.getRelatedArticles();

--- a/src/article/components/ManuscriptComponent.js
+++ b/src/article/components/ManuscriptComponent.js
@@ -187,6 +187,26 @@ export default class ManuscriptComponent extends Component {
       ),
     );
 
+    // Keywords
+    el.append(
+      $$(ManuscriptSection, {
+        name: 'article-information-keywords',
+        label: this.getLabel('article-information-keywords-label'),
+        model: [],
+        hideWhenEmpty: false,
+      }),
+    );
+
+    // Research Organisms
+    el.append(
+      $$(ManuscriptSection, {
+        name: 'article-information-research-organisms',
+        label: this.getLabel('article-information-research-organisms-label'),
+        model: [],
+        hideWhenEmpty: false,
+      }),
+    );
+
     // Article Type
     el.append(
       $$(ManuscriptSection, {

--- a/src/article/components/ManuscriptComponent.js
+++ b/src/article/components/ManuscriptComponent.js
@@ -162,17 +162,42 @@ export default class ManuscriptComponent extends Component {
     );
 
     // Article Information
-    const subjectsModel = manuscript.getSubjects();
     el.append(
       $$(ManuscriptSection, {
         name: 'article-information',
         label: this.getLabel('article-information-label'),
+        model: [],
+        hideWhenEmpty: false,
+      }),
+    );
+
+    // Subjects
+    const subjectsModel = manuscript.getSubjects();
+    el.append(
+      $$(ManuscriptSection, {
+        name: 'article-information-subjects',
+        label: this.getLabel('article-information-subjects-label'),
         model: subjectsModel,
         hideWhenEmpty: false,
       }).append(
         $$(SubjectsListComponent, {
           model: subjectsModel,
           type: 'subject',
+        }).addClass('sm-subjects-list'),
+      ),
+    );
+
+    // Article Type
+    el.append(
+      $$(ManuscriptSection, {
+        name: 'article-information-type',
+        label: this.getLabel('article-information-type-label'),
+        model: subjectsModel,
+        hideWhenEmpty: false,
+      }).append(
+        $$(SubjectsListComponent, {
+          model: subjectsModel,
+          type: 'heading',
         }).addClass('sm-subjects-list'),
       ),
     );

--- a/src/article/components/ManuscriptComponent.js
+++ b/src/article/components/ManuscriptComponent.js
@@ -14,7 +14,6 @@ export default class ManuscriptComponent extends Component {
     const AuthorDetailsListComponent = this.getComponent('author-details-list');
     const ReferenceListComponent = this.getComponent('reference-list');
     const RelatedArticlesListComponent = this.getComponent('related-articles-list');
-    //const SubjectsListComponent = this.getComponent('subjects-list');
 
     const el = $$('div').addClass('sc-manuscript');
 
@@ -170,74 +169,15 @@ export default class ManuscriptComponent extends Component {
       $$(ManuscriptSection, {
         name: 'article-information',
         label: this.getLabel('article-information-label'),
-        model: [],
+        model: this.props.model,
         hideWhenEmpty: false,
       }).append(
         $$(ArticleInformationComponent, {
-          model: [],
+          model: this.props.model,
+          manuscript: this,
         }),
       ),
     );
-
-    // el.append(
-    //   $$(ManuscriptSection, {
-    //     name: 'article-information',
-    //     label: this.getLabel('article-information-label'),
-    //     model: [],
-    //     hideWhenEmpty: false,
-    //   }),
-    // );
-
-    // // Subjects
-    // const subjectsModel = manuscript.getSubjects();
-    // el.append(
-    //   $$(ManuscriptSection, {
-    //     name: 'article-information-subjects',
-    //     label: this.getLabel('article-information-subjects-label'),
-    //     model: subjectsModel,
-    //     hideWhenEmpty: false,
-    //   }).append(
-    //     $$(SubjectsListComponent, {
-    //       model: subjectsModel,
-    //       type: 'subject',
-    //     }).addClass('sm-subjects-list'),
-    //   ),
-    // );
-
-    // // Keywords
-    // el.append(
-    //   $$(ManuscriptSection, {
-    //     name: 'article-information-keywords',
-    //     label: this.getLabel('article-information-keywords-label'),
-    //     model: [],
-    //     hideWhenEmpty: false,
-    //   }),
-    // );
-
-    // // Research Organisms
-    // el.append(
-    //   $$(ManuscriptSection, {
-    //     name: 'article-information-research-organisms',
-    //     label: this.getLabel('article-information-research-organisms-label'),
-    //     model: [],
-    //     hideWhenEmpty: false,
-    //   }),
-    // );
-
-    // // Article Type
-    // el.append(
-    //   $$(ManuscriptSection, {
-    //     name: 'article-information-type',
-    //     label: this.getLabel('article-information-type-label'),
-    //     model: subjectsModel,
-    //     hideWhenEmpty: false,
-    //   }).append(
-    //     $$(SubjectsListComponent, {
-    //       model: subjectsModel,
-    //       type: 'heading',
-    //     }).addClass('sm-subjects-list'),
-    //   ),
-    // );
 
     // Related Articles
     const relatedArticlesModel = manuscript.getRelatedArticles();

--- a/src/article/components/ManuscriptTOC.js
+++ b/src/article/components/ManuscriptTOC.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import { Component, domHelpers, DefaultDOMElement } from 'substance';
 import { ValueComponent, renderModel, createValueModel } from '../../kit';
 
@@ -5,10 +6,10 @@ import { ValueComponent, renderModel, createValueModel } from '../../kit';
 // TODO: we should follow the same approach as in Metadata, i.e. having a model which is a list of sections
 export default class ManuscriptTOC extends Component {
   render($$) {
-    let el = $$('div').addClass('sc-toc');
-    let manuscriptModel = this.props.model;
+    const el = $$('div').addClass('sc-toc');
+    const manuscriptModel = this.props.model;
 
-    let tocEntries = $$('div')
+    const tocEntries = $$('div')
       .addClass('se-toc-entries')
       .ref('tocEntries')
       .on('click', domHelpers.stop);
@@ -84,7 +85,7 @@ export default class ManuscriptTOC extends Component {
 class SectionTOCEntry extends Component {
   render($$) {
     const { label, section } = this.props;
-    let el = $$('a')
+    const el = $$('a')
       .addClass('sc-toc-entry sm-level-1')
       .attr({ 'data-section': section })
       .on('click', this._onClick)
@@ -101,13 +102,13 @@ class SectionTOCEntry extends Component {
 
 class BodyTOCEntry extends ValueComponent {
   render($$) {
-    let items = this.props.model.getItems();
-    let headings = items.filter(node => node.type === 'heading');
+    const items = this.props.model.getItems();
+    const headings = items.filter(node => node.type === 'heading');
     return $$('div')
       .addClass('sc-toc-entry')
       .append(
         headings.map(heading => {
-          let el = $$(TOCHeadingEntry, { node: heading })
+          const el = $$(TOCHeadingEntry, { node: heading })
             .ref(heading.id)
             .addClass(`sc-toc-entry sm-level-${heading.level}`)
             .attr({ 'data-id': heading.id })
@@ -118,8 +119,8 @@ class BodyTOCEntry extends ValueComponent {
   }
 
   _onClick(event) {
-    let target = DefaultDOMElement.wrap(event.currentTarget);
-    let nodeId = target.attr('data-id');
+    const target = DefaultDOMElement.wrap(event.currentTarget);
+    const nodeId = target.attr('data-id');
     event.preventDefault();
     event.stopPropagation();
     this.send('scrollTo', { nodeId });
@@ -138,7 +139,7 @@ class TOCHeadingEntry extends Component {
   }
   render($$) {
     const api = this.context.api;
-    let heading = this.props.node;
+    const heading = this.props.node;
     return $$('div').append(renderModel($$, this, createValueModel(api, heading.getPath()), { readOnly: true }));
   }
 }
@@ -146,8 +147,8 @@ class TOCHeadingEntry extends Component {
 // only visible when collection not empty
 class DynamicTOCEntry extends ValueComponent {
   render($$) {
-    let { label, model, section } = this.props;
-    let el = $$('div')
+    const { label, model, section } = this.props;
+    const el = $$('div')
       .addClass('sc-toc-entry sm-level-1')
       .attr({ 'data-section': section })
       .on('click', this._onClick)

--- a/src/article/components/ManuscriptTOC.js
+++ b/src/article/components/ManuscriptTOC.js
@@ -57,6 +57,20 @@ export default class ManuscriptTOC extends Component {
       }),
     );
 
+    tocEntries.append(
+      $$(SectionTOCEntry, {
+        label: this.getLabel('author-details-label'),
+        section: 'author-details',
+      }),
+    );
+
+    tocEntries.append(
+      $$(SectionTOCEntry, {
+        label: this.getLabel('article-information-label'),
+        section: 'article-information',
+      }),
+    );
+
     el.append(tocEntries);
 
     return el;

--- a/src/article/components/PermissionComponent.js
+++ b/src/article/components/PermissionComponent.js
@@ -4,7 +4,7 @@ export default class PermissionComponent extends NodeComponent {
   render($$) {
     const node = this.props.node;
     const Button = this.getComponent('button');
-    let el = $$('div').addClass('sc-content');
+    const el = $$('div').addClass('sc-content');
     el.append(
       $$(Button, {
         icon: 'remove',

--- a/src/article/components/PermissionComponent.js
+++ b/src/article/components/PermissionComponent.js
@@ -7,7 +7,7 @@ export default class PermissionComponent extends NodeComponent {
     const el = $$('div').addClass('sc-content');
     el.append(
       $$(Button, {
-        icon: 'remove',
+        icon: 'trash',
       })
         .addClass('se-remove-value')
         .on('click', this._onRemove),

--- a/src/article/components/RelatedArticleComponent.js
+++ b/src/article/components/RelatedArticleComponent.js
@@ -1,9 +1,10 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import { CustomSurface } from 'substance';
 import { FormRowComponent, NodeComponent } from '../../kit';
 
 export default class RelatedArticleListComponent extends CustomSurface {
   getInitialState() {
-    let items = this._getRelatedArticles();
+    const items = this._getRelatedArticles();
     return {
       hidden: items.length === 0,
       edit: false,
@@ -32,7 +33,7 @@ export default class RelatedArticleListComponent extends CustomSurface {
   }
 
   render($$) {
-    let el = $$('div').addClass('sc-related-articles-list');
+    const el = $$('div').addClass('sc-related-articles-list');
     el.append(this._renderRelatedArticles($$));
     return el;
   }
@@ -40,7 +41,7 @@ export default class RelatedArticleListComponent extends CustomSurface {
   _renderRelatedArticles($$) {
     const sel = this.context.editorState.selection;
     const relatedArticles = this._getRelatedArticles();
-    let els = [];
+    const els = [];
     relatedArticles.forEach((relatedArticle, index) => {
       const relatedArticleEl = $$(RelatedArticleComponent, { node: relatedArticle }).ref(relatedArticle.id);
       if (sel && sel.nodeId === relatedArticle.id) {
@@ -70,12 +71,12 @@ export default class RelatedArticleListComponent extends CustomSurface {
 
 class RelatedArticleComponent extends NodeComponent {
   render($$) {
-    let node = this.props.node;
+    const node = this.props.node;
 
     const Button = this.getComponent('button');
 
     // Card
-    let el = $$('div')
+    const el = $$('div')
       .addClass('sc-card')
       .attr('data-id', node.id)
       .append(
@@ -89,7 +90,7 @@ class RelatedArticleComponent extends NodeComponent {
         .addClass('sc-header')
         .append(
           $$(Button, {
-            icon: 'remove',
+            icon: 'trash',
           })
             .addClass('se-button')
             .on('click', this._onRemove),

--- a/src/article/components/SubjectEditor.js
+++ b/src/article/components/SubjectEditor.js
@@ -1,4 +1,28 @@
 import DropdownEditor from '../shared/DropdownEditor';
+import { PREVIEW_MODE } from '../ArticleConstants';
+
+const subjectTypes = [
+  'Biochemistry and Chemical Biology',
+  'Cancer Biology',
+  'Cell Biology',
+  'Chromosomes and Gene Expression',
+  'Computational and Systems Biology',
+  'Developmental Biology',
+  'Ecology',
+  'Epidemiology and Global Health',
+  'Evolutionary Biology',
+  'Genetics and Genomics',
+  'Human Biology and Medicine',
+  'Immunology and Inflammation',
+  'Microbiology and Infectious Disease',
+  'Neuroscience',
+  'Physics of Living Systems',
+  'Plant Biology',
+  'Stem Cells and Regenerative Medicine',
+  'Structural Biology and Molecular Biophysics',
+];
+
+const articleTypes = ['Insight', 'Research article', 'Tools and resources', 'Short report', 'Editorial'];
 
 export default class SubjectEditor extends DropdownEditor {
   _getLabel() {
@@ -14,23 +38,19 @@ export default class SubjectEditor extends DropdownEditor {
   _getValues() {
     let values = [];
     if (this.props.subjectType === 'subject') {
-      values = [
-        {
-          id: 'Chromosomes and Gene Expression',
-          name: 'Chromosomes and Gene Expression',
-        },
-        {
-          id: 'Genetics and Genomics',
-          name: 'Genetics and Genomics',
-        },
-      ];
+      values = subjectTypes.map(subjectType => {
+        return {
+          id: subjectType,
+          name: subjectType,
+        };
+      });
     } else if (this.props.subjectType === 'heading') {
-      values = [
-        {
-          id: 'Insight',
-          name: 'Insight',
-        },
-      ];
+      values = articleTypes.map(articleType => {
+        return {
+          id: articleType,
+          name: articleType,
+        };
+      });
     }
     return values;
   }

--- a/src/article/components/SubjectEditor.js
+++ b/src/article/components/SubjectEditor.js
@@ -1,0 +1,60 @@
+import DropdownEditor from '../shared/DropdownEditor';
+import { domHelpers } from 'substance';
+
+export default class SubjectEditor extends DropdownEditor {
+  _getLabel() {
+    return this.getLabel('select-subject');
+  }
+
+  _getValues() {
+    return [
+      {
+        id: 'hello',
+        name: 'hello',
+      },
+      {
+        id: 'world',
+        name: 'world',
+      },
+    ];
+  }
+
+  render($$) {
+    const value = this.props.name;
+    const el = $$('div').addClass(this._getClassNames());
+
+    const dropdownSelector = $$('select')
+      .ref('input')
+      .addClass('se-select')
+      .val(value)
+      .on('click', domHelpers.stop)
+      .on('change', this._setValue);
+
+    dropdownSelector.append($$('option').append(this._getLabel()));
+
+    this._getValues().forEach(l => {
+      const option = $$('option')
+        .attr({ value: l.id })
+        .append(l.name);
+      if (l.id === value) option.attr({ selected: 'selected' });
+      dropdownSelector.append(option);
+    });
+
+    el.append(dropdownSelector);
+
+    return el;
+  }
+
+  _getClassNames() {
+    return 'sc-dropdown-editor';
+  }
+
+  _setValue() {
+    const node = this.props.node;
+    const input = this.refs.input;
+    const value = input.getValue();
+
+    // FIXME: This should create a transaction!
+    node.name = value;
+  }
+}

--- a/src/article/components/SubjectEditor.js
+++ b/src/article/components/SubjectEditor.js
@@ -1,28 +1,5 @@
 import DropdownEditor from '../shared/DropdownEditor';
-import { PREVIEW_MODE } from '../ArticleConstants';
-
-const subjectTypes = [
-  'Biochemistry and Chemical Biology',
-  'Cancer Biology',
-  'Cell Biology',
-  'Chromosomes and Gene Expression',
-  'Computational and Systems Biology',
-  'Developmental Biology',
-  'Ecology',
-  'Epidemiology and Global Health',
-  'Evolutionary Biology',
-  'Genetics and Genomics',
-  'Human Biology and Medicine',
-  'Immunology and Inflammation',
-  'Microbiology and Infectious Disease',
-  'Neuroscience',
-  'Physics of Living Systems',
-  'Plant Biology',
-  'Stem Cells and Regenerative Medicine',
-  'Structural Biology and Molecular Biophysics',
-];
-
-const articleTypes = ['Insight', 'Research article', 'Tools and resources', 'Short report', 'Editorial'];
+import { ARTICLE_SUBJECTS, ARTICLE_TYPES } from '../ArticleConstants';
 
 export default class SubjectEditor extends DropdownEditor {
   _getLabel() {
@@ -38,14 +15,14 @@ export default class SubjectEditor extends DropdownEditor {
   _getValues() {
     let values = [];
     if (this.props.subjectType === 'subject') {
-      values = subjectTypes.map(subjectType => {
+      values = ARTICLE_SUBJECTS.map(subjectType => {
         return {
           id: subjectType,
           name: subjectType,
         };
       });
     } else if (this.props.subjectType === 'heading') {
-      values = articleTypes.map(articleType => {
+      values = ARTICLE_TYPES.map(articleType => {
         return {
           id: articleType,
           name: articleType,

--- a/src/article/components/SubjectEditor.js
+++ b/src/article/components/SubjectEditor.js
@@ -1,60 +1,37 @@
 import DropdownEditor from '../shared/DropdownEditor';
-import { domHelpers } from 'substance';
 
 export default class SubjectEditor extends DropdownEditor {
   _getLabel() {
-    return this.getLabel('select-subject');
+    let label = 'Select';
+    if (this.props.subjectType === 'subject') {
+      label = this.getLabel('select-subject');
+    } else if (this.props.subjectType === 'heading') {
+      label = this.getLabel('select-heading');
+    }
+    return label;
   }
 
   _getValues() {
-    return [
-      {
-        id: 'hello',
-        name: 'hello',
-      },
-      {
-        id: 'world',
-        name: 'world',
-      },
-    ];
-  }
-
-  render($$) {
-    const value = this.props.name;
-    const el = $$('div').addClass(this._getClassNames());
-
-    const dropdownSelector = $$('select')
-      .ref('input')
-      .addClass('se-select')
-      .val(value)
-      .on('click', domHelpers.stop)
-      .on('change', this._setValue);
-
-    dropdownSelector.append($$('option').append(this._getLabel()));
-
-    this._getValues().forEach(l => {
-      const option = $$('option')
-        .attr({ value: l.id })
-        .append(l.name);
-      if (l.id === value) option.attr({ selected: 'selected' });
-      dropdownSelector.append(option);
-    });
-
-    el.append(dropdownSelector);
-
-    return el;
-  }
-
-  _getClassNames() {
-    return 'sc-dropdown-editor';
-  }
-
-  _setValue() {
-    const node = this.props.node;
-    const input = this.refs.input;
-    const value = input.getValue();
-
-    // FIXME: This should create a transaction!
-    node.name = value;
+    let values = [];
+    if (this.props.subjectType === 'subject') {
+      values = [
+        {
+          id: 'Chromosomes and Gene Expression',
+          name: 'Chromosomes and Gene Expression',
+        },
+        {
+          id: 'Genetics and Genomics',
+          name: 'Genetics and Genomics',
+        },
+      ];
+    } else if (this.props.subjectType === 'heading') {
+      values = [
+        {
+          id: 'Insight',
+          name: 'Insight',
+        },
+      ];
+    }
+    return values;
   }
 }

--- a/src/article/components/SubjectsListComponent.js
+++ b/src/article/components/SubjectsListComponent.js
@@ -48,7 +48,8 @@ export default class SubjectsListComponent extends CustomSurface {
   }
 
   _getCustomResourceId() {
-    return 'subjects-list';
+    // FIXME: This seems like a hack to me, need to take a deeper look at this.
+    return 'subjects-list-' + (this.props.type || 'default');
   }
 
   _getSubjects(type) {

--- a/src/article/components/SubjectsListComponent.js
+++ b/src/article/components/SubjectsListComponent.js
@@ -3,6 +3,7 @@ import { CustomSurface } from 'substance';
 import { NodeComponent } from '../../kit';
 import { default as SubjectEditor } from './SubjectEditor';
 import { getLabel } from '../shared/nodeHelpers';
+import { createValueModel } from '../../kit/model/index';
 
 export default class SubjectsListComponent extends CustomSurface {
   getInitialState() {
@@ -35,11 +36,15 @@ export default class SubjectsListComponent extends CustomSurface {
   }
 
   _renderSubjects($$) {
+    const api = this.context.api;
     const sel = this.context.editorState.selection;
     const subjects = this._getSubjects(this.props.type);
     const els = [];
     subjects.forEach((subject, index) => {
-      const subjectElement = $$(SubjectEditor, { node: subject }).ref(subject.id);
+      // TODO: So here, I need to create a 'model' for the subject, and then pass that through to the SubjectEditor.
+      //       Issue that I have is I don't know how to properly construct a model!
+      const model = createValueModel(api, [subject.id, 'name']);
+      const subjectElement = $$(SubjectEditor, { model, subjectType: subject.groupType }).ref(subject.id);
       if (sel && sel.nodeId === subject.id) {
         subjectElement.addClass('sm-selected');
       }

--- a/src/article/components/SubjectsListComponent.js
+++ b/src/article/components/SubjectsListComponent.js
@@ -1,8 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { CustomSurface } from 'substance';
-import { NodeComponent } from '../../kit';
 import { default as SubjectEditor } from './SubjectEditor';
-import { getLabel } from '../shared/nodeHelpers';
 import { createValueModel } from '../../kit/model/index';
 
 export default class SubjectsListComponent extends CustomSurface {
@@ -40,9 +38,7 @@ export default class SubjectsListComponent extends CustomSurface {
     const sel = this.context.editorState.selection;
     const subjects = this._getSubjects(this.props.type);
     const els = [];
-    subjects.forEach((subject, index) => {
-      // TODO: So here, I need to create a 'model' for the subject, and then pass that through to the SubjectEditor.
-      //       Issue that I have is I don't know how to properly construct a model!
+    subjects.forEach(subject => {
       const model = createValueModel(api, [subject.id, 'name']);
       const subjectElement = $$(SubjectEditor, { model, subjectType: subject.groupType }).ref(subject.id);
       if (sel && sel.nodeId === subject.id) {
@@ -54,7 +50,7 @@ export default class SubjectsListComponent extends CustomSurface {
   }
 
   _getCustomResourceId() {
-    // FIXME: This seems like a hack to me, need to take a deeper look at this.
+    // FIXME: I'm not entirely sure that this is a decent solution, but it does the job for now.
     return 'subjects-list-' + (this.props.type || 'default');
   }
 
@@ -64,32 +60,5 @@ export default class SubjectsListComponent extends CustomSurface {
       subjects = subjects.filter(subject => subject.groupType === type);
     }
     return subjects;
-  }
-}
-
-class SubjectDisplay extends NodeComponent {
-  render($$) {
-    const subject = this.props.node;
-    // FIXME: Need a better CSS class here
-    const el = $$('span').addClass('se-contrib');
-    el.append(this.context.api.renderEntity(subject));
-    el.on('mousedown', this._onMousedown).on('click', this._onClick);
-    return el;
-  }
-
-  _onMousedown(e) {
-    e.stopPropagation();
-    if (e.button === 2) {
-      this._select();
-    }
-  }
-
-  _onClick(e) {
-    e.stopPropagation();
-    this._select();
-  }
-
-  _select() {
-    this.context.api.selectEntity(this.props.node.id);
   }
 }

--- a/src/article/components/SubjectsListComponent.js
+++ b/src/article/components/SubjectsListComponent.js
@@ -1,0 +1,88 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import { CustomSurface } from 'substance';
+import { NodeComponent } from '../../kit';
+import { getLabel } from '../shared/nodeHelpers';
+
+export default class SubjectsListComponent extends CustomSurface {
+  getInitialState() {
+    const items = this._getSubjects();
+    return {
+      hidden: items.length === 0,
+      edit: false,
+    };
+  }
+
+  didMount() {
+    super.didMount();
+
+    const appState = this.context.editorState;
+    // FIXME: it is not good to rerender on every selection change.
+    // Instead it should derive a state from the selection, and only rerender if the
+    // state has changed (not-selected, selected + author id)
+    appState.addObserver(['selection'], this.rerender, this, { stage: 'render' });
+  }
+
+  dispose() {
+    super.dispose();
+    this.context.editorState.removeObserver(this);
+  }
+
+  render($$) {
+    const el = $$('div').addClass('sc-subjects-list');
+    el.append(this._renderSubjects($$));
+    return el;
+  }
+
+  _renderSubjects($$) {
+    const sel = this.context.editorState.selection;
+    const subjects = this._getSubjects(this.props.type);
+    const els = [];
+    subjects.forEach((subject, index) => {
+      const subjectElement = $$(SubjectDisplay, { node: subject }).ref(subject.id);
+      if (sel && sel.nodeId === subject.id) {
+        subjectElement.addClass('sm-selected');
+      }
+      els.push(subjectElement);
+    });
+    return els;
+  }
+
+  _getCustomResourceId() {
+    return 'subjects-list';
+  }
+
+  _getSubjects(type) {
+    let subjects = this.props.model.getItems();
+    if (type) {
+      subjects = subjects.filter(subject => subject.groupType === type);
+    }
+    return subjects;
+  }
+}
+
+class SubjectDisplay extends NodeComponent {
+  render($$) {
+    const subject = this.props.node;
+    // FIXME: Need a better CSS class here
+    const el = $$('span').addClass('se-contrib');
+    el.append(this.context.api.renderEntity(subject));
+    el.on('mousedown', this._onMousedown).on('click', this._onClick);
+    return el;
+  }
+
+  _onMousedown(e) {
+    e.stopPropagation();
+    if (e.button === 2) {
+      this._select();
+    }
+  }
+
+  _onClick(e) {
+    e.stopPropagation();
+    this._select();
+  }
+
+  _select() {
+    this.context.api.selectEntity(this.props.node.id);
+  }
+}

--- a/src/article/components/SubjectsListComponent.js
+++ b/src/article/components/SubjectsListComponent.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import { CustomSurface } from 'substance';
 import { NodeComponent } from '../../kit';
+import { default as SubjectEditor } from './SubjectEditor';
 import { getLabel } from '../shared/nodeHelpers';
 
 export default class SubjectsListComponent extends CustomSurface {
@@ -38,7 +39,7 @@ export default class SubjectsListComponent extends CustomSurface {
     const subjects = this._getSubjects(this.props.type);
     const els = [];
     subjects.forEach((subject, index) => {
-      const subjectElement = $$(SubjectDisplay, { node: subject }).ref(subject.id);
+      const subjectElement = $$(SubjectEditor, { node: subject }).ref(subject.id);
       if (sel && sel.nodeId === subject.id) {
         subjectElement.addClass('sm-selected');
       }

--- a/src/article/components/index.js
+++ b/src/article/components/index.js
@@ -33,6 +33,7 @@ export { default as InsertFigureTool } from './InsertFigureTool';
 export { default as InsertInlineGraphicTool } from './InsertInlineGraphicTool';
 export { default as InsertTableTool } from './InsertTableTool';
 export { default as ItalicComponent } from './ItalicComponent';
+export { default as KeywordsListComponent } from './KeywordsListComponent';
 export { default as LabelComponent } from './LabelComponent';
 export { default as LicenseEditor } from './LicenseEditor';
 export { default as ListComponent } from './ListComponent';

--- a/src/article/components/index.js
+++ b/src/article/components/index.js
@@ -2,6 +2,7 @@ export { default as AbstractComponent } from './AbstractComponent';
 export { default as AcknowledgementComponent } from './AcknowledgementComponent';
 export { default as AddSupplementaryFileWorkflow } from './AddSupplementaryFileWorkflow';
 export { default as AffiliationsListComponent } from './AffiliationsListComponent';
+export { default as ArticleInformationComponent } from './ArticleInformationComponent';
 export { default as AuthorsListComponent } from './AuthorsListComponent';
 export { default as AuthorDetailsListComponent } from './AuthorDetailsListComponent';
 export { default as BlockFormulaComponent } from './BlockFormulaComponent';

--- a/src/article/components/index.js
+++ b/src/article/components/index.js
@@ -33,6 +33,7 @@ export { default as InsertFigureTool } from './InsertFigureTool';
 export { default as InsertInlineGraphicTool } from './InsertInlineGraphicTool';
 export { default as InsertTableTool } from './InsertTableTool';
 export { default as ItalicComponent } from './ItalicComponent';
+export { default as KeywordComponent } from './KeywordComponent';
 export { default as KeywordsListComponent } from './KeywordsListComponent';
 export { default as LabelComponent } from './LabelComponent';
 export { default as LicenseEditor } from './LicenseEditor';

--- a/src/article/components/index.js
+++ b/src/article/components/index.js
@@ -55,6 +55,7 @@ export { default as ReplaceFigurePanelTool } from './ReplaceFigurePanelTool';
 export { default as ReplaceSupplementaryFileTool } from './ReplaceSupplementaryFileTool';
 export { default as SectionLabel } from './SectionLabel';
 export { default as SpecificUseEditor } from './SpecificUseEditor';
+export { default as SubjectsListComponent } from './SubjectsListComponent';
 export { default as SubscriptComponent } from './SubscriptComponent';
 export { default as SuperscriptComponent } from './SuperscriptComponent';
 export { default as SupplementaryFileComponent } from './SupplementaryFileComponent';

--- a/src/article/converter/jats/internal2jats.js
+++ b/src/article/converter/jats/internal2jats.js
@@ -490,19 +490,31 @@ function _exportKeywords(jats, doc, jatsExporter) {
   const $$ = jats.$$;
   // TODO: remove or rework tranlations of keywords
   const keywords = doc.resolve(['metadata', 'keywords']);
-  const byLang = keywords.reduce((byLang, keyword) => {
-    const lang = keyword.language;
-    if (!byLang[lang]) {
-      byLang[lang] = [];
+
+  // FIXME: I've change the export behaviour here based on groupType. This should be driven be a configuration value!
+  const byGroupType = keywords.reduce((byGroupType, keyword) => {
+    const groupType = keyword.language;
+    if (!byGroupType[groupType]) {
+      byGroupType[groupType] = [];
     }
-    byLang[lang].push(keyword);
-    return byLang;
+    byGroupType[groupType].push(keyword);
+    return byGroupType;
   }, {});
+
+  // const byLang = keywords.reduce((byLang, keyword) => {
+  //   const lang = keyword.language;
+  //   if (!byLang[lang]) {
+  //     byLang[lang] = [];
+  //   }
+  //   byLang[lang].push(keyword);
+  //   return byLang;
+  // }, {});
+
   const keywordGroups = [];
-  forEach(byLang, (keywords, lang) => {
+  forEach(byGroupType, (keywords, groupType) => {
     const groupEl = $$('kwd-group');
-    if (lang !== 'undefined') {
-      groupEl.attr('xml:lang', lang);
+    if (groupType !== 'undefined') {
+      groupEl.attr('kwd-group-type ', groupType);
     }
     groupEl.append(
       keywords.map(keyword => {

--- a/src/article/converter/jats/jats2internal.js
+++ b/src/article/converter/jats/jats2internal.js
@@ -1,7 +1,7 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import { uuid, documentHelpers } from 'substance';
 import { findChild, getText, retainChildren } from '../util/domHelpers';
 import SectionContainerConverter from './SectionContainerConverter';
-import { RelatedArticle } from '../../nodes';
 
 export default function jats2internal(jats, doc, jatsImporter) {
   // metadata
@@ -26,12 +26,13 @@ export default function jats2internal(jats, doc, jatsImporter) {
 
   return doc;
 }
+
 function _populateAffiliations(doc, jats) {
   // FIXME: At the moment we are ONLY getting affiliations for Authors, so we are missing editors, etc. I think that
   //        to properly support them all we need to re-model the metadata model.
   const affEls = jats.findAll('article > front > article-meta > contrib-group[content-type=author] > aff');
-  let orgIds = affEls.map(el => {
-    let org = {
+  const orgIds = affEls.map(el => {
+    const org = {
       id: el.id,
       type: 'affiliation',
       institution: getText(el, 'institution[content-type=orgname]') || getText(el, 'institution:not([content-type])'),
@@ -55,21 +56,21 @@ function _populateAffiliations(doc, jats) {
 }
 
 function _populateAuthors(doc, jats, importer) {
-  let authorEls = jats.findAll(`contrib-group[content-type=author] > contrib`);
+  const authorEls = jats.findAll(`contrib-group[content-type=author] > contrib`);
   _populateContribs(doc, jats, importer, ['metadata', 'authors'], authorEls);
 }
 
 function _populateEditors(doc, jats, importer) {
-  let editorEls = jats.findAll(`contrib-group[content-type=editor] > contrib`);
+  const editorEls = jats.findAll(`contrib-group[content-type=editor] > contrib`);
   _populateContribs(doc, jats, importer, ['metadata', 'editors'], editorEls);
 }
 
 function _populateContribs(doc, jats, importer, contribsPath, contribEls, groupId) {
-  for (let contribEl of contribEls) {
+  for (const contribEl of contribEls) {
     if (contribEl.attr('contrib-type') === 'group') {
       // ATTENTION: groups are defined 'inplace'
       // the members of the group are appended to the list of persons
-      let group = {
+      const group = {
         id: contribEl.id,
         type: 'group',
         name: getText(contribEl, 'named-content[content-type=name]'),
@@ -81,10 +82,10 @@ function _populateContribs(doc, jats, importer, contribsPath, contribEls, groupI
       };
       documentHelpers.append(doc, ['metadata', 'groups'], doc.create(group).id);
 
-      let memberEls = contribEl.findAll('contrib');
+      const memberEls = contribEl.findAll('contrib');
       _populateContribs(doc, jats, importer, contribsPath, memberEls, group.id);
     } else {
-      let contrib = doc.create({
+      const contrib = doc.create({
         id: contribEl.id,
         type: 'person',
         givenNames: getText(contribEl, 'given-names'),
@@ -109,9 +110,9 @@ function _populateContribs(doc, jats, importer, contribsPath, contribEls, groupI
 }
 
 function _populateAuthorNotes(doc, jats, jatsImporter) {
-  let $$ = jats.createElement.bind(jats);
-  let fnEls = jats.findAll('article > front > article-meta > author-notes > fn');
-  let article = doc.get('article');
+  const $$ = jats.createElement.bind(jats);
+  const fnEls = jats.findAll('article > front > article-meta > author-notes > fn');
+  const article = doc.get('article');
   article.authorNotes = fnEls.map(fnEl => {
     // there must be at least one paragraph
     if (!fnEl.find('p')) {
@@ -122,14 +123,14 @@ function _populateAuthorNotes(doc, jats, jatsImporter) {
 }
 
 function _getAuthorCompetingInterests(el, importer) {
-  let xrefs = el.findAll('xref[ref-type=fn]');
-  let ids = xrefs.map(xref => xref.attr('rid'));
+  const xrefs = el.findAll('xref[ref-type=fn]');
+  const ids = xrefs.map(xref => xref.attr('rid'));
   return ids;
 }
 
 // ATTENTION: bio is not a specific node anymore, just a collection of paragraphs
 function _getBioContent(el, importer) {
-  let $$ = el.createElement.bind(el.getOwnerDocument());
+  const $$ = el.createElement.bind(el.getOwnerDocument());
   let bioEl = findChild(el, 'bio');
   // If there is no bio element we should provide it
   if (!bioEl) {
@@ -154,26 +155,26 @@ function _getAffiliationIds(el, isGroup) {
   if (isGroup) {
     xrefs = el.findAll('collab > xref[ref-type=aff]');
   }
-  let affs = xrefs.map(xref => xref.attr('rid'));
+  const affs = xrefs.map(xref => xref.attr('rid'));
   return affs;
 }
 
 function _getContributorIds(el, importer) {
-  let elements = el.findAll('contrib-id');
-  let contributorIds = elements.map(element => importer.convertElement(element).id);
+  const elements = el.findAll('contrib-id');
+  const contributorIds = elements.map(element => importer.convertElement(element).id);
   return contributorIds;
 }
 
 function _getAwardIds(el) {
-  let xrefs = el.findAll('xref[ref-type=award]');
-  let awardIds = xrefs.map(xref => xref.attr('rid'));
+  const xrefs = el.findAll('xref[ref-type=award]');
+  const awardIds = xrefs.map(xref => xref.attr('rid'));
   return awardIds;
 }
 
 function _populateFunders(doc, jats) {
   const awardEls = jats.findAll('article > front > article-meta > funding-group > award-group');
-  let funderIds = awardEls.map(el => {
-    let funder = {
+  const funderIds = awardEls.map(el => {
+    const funder = {
       id: el.id,
       type: 'funder',
       institution: getText(el, 'institution'),
@@ -187,9 +188,9 @@ function _populateFunders(doc, jats) {
 
 // TODO: use doc API for manipulation, not a bare object
 function _populateArticleInfo(doc, jats, jatsImporter) {
-  let articleEl = jats.find('article');
-  let articleMetaEl = articleEl.find('front > article-meta');
-  let metadata = doc.get('metadata');
+  const articleEl = jats.find('article');
+  const articleMetaEl = articleEl.find('front > article-meta');
+  const metadata = doc.get('metadata');
   Object.assign(metadata, {
     articleType: articleEl.getAttribute('article-type') || '',
     elocationId: getText(articleMetaEl, 'elocation-id'),
@@ -199,7 +200,7 @@ function _populateArticleInfo(doc, jats, jatsImporter) {
     volume: getText(articleMetaEl, 'volume'),
     pageRange: getText(articleMetaEl, 'page-range'),
   });
-  let issueTitleEl = findChild(articleMetaEl, 'issue-title');
+  const issueTitleEl = findChild(articleMetaEl, 'issue-title');
   if (issueTitleEl) {
     metadata['issueTitle'] = jatsImporter.annotatedText(issueTitleEl, ['metadata', 'issueTtle']);
   }
@@ -208,7 +209,7 @@ function _populateArticleInfo(doc, jats, jatsImporter) {
   // An empty permission is already there, but will be replaced if <permission> element is there
   if (permissionsEl) {
     doc.delete(metadata.permission);
-    let permission = jatsImporter.convertElement(permissionsEl);
+    const permission = jatsImporter.convertElement(permissionsEl);
     // ATTENTION: so that the document model is correct we need to use
     // the Document API  to set the permission id
     metadata.permission = permission.id;
@@ -216,7 +217,7 @@ function _populateArticleInfo(doc, jats, jatsImporter) {
 
   const articleDateEls = articleMetaEl.findAll('history > date, pub-date');
   if (articleDateEls.length > 0) {
-    let dates = {};
+    const dates = {};
     articleDateEls.forEach(dateEl => {
       const date = _extractDate(dateEl);
       dates[date.type] = date.value;
@@ -244,8 +245,8 @@ function _extractDate(el) {
 }
 
 function _populateKeywords(doc, jats, jatsImporter) {
-  let kwdEls = jats.findAll('article > front > article-meta > kwd-group > kwd');
-  let kwdIds = kwdEls.map(kwdEl => {
+  const kwdEls = jats.findAll('article > front > article-meta > kwd-group > kwd');
+  const kwdIds = kwdEls.map(kwdEl => {
     const kwd = doc.create({
       type: 'keyword',
       category: kwdEl.getAttribute('content-type'),
@@ -258,8 +259,8 @@ function _populateKeywords(doc, jats, jatsImporter) {
 }
 
 function _populateRelatedArticles(doc, jats, jatsImporter) {
-  let relatedArticleEls = jats.findAll('article > front > article-meta > related-article');
-  let relatedArticleIds = relatedArticleEls.map(relatedArticleEl => {
+  const relatedArticleEls = jats.findAll('article > front > article-meta > related-article');
+  const relatedArticleIds = relatedArticleEls.map(relatedArticleEl => {
     const relatedArticle = doc.create({
       type: 'related-article',
       extLinkType: relatedArticleEl.getAttribute('ext-link-type'),
@@ -277,17 +278,19 @@ function _populateSubjects(doc, jats) {
   // to be able to define an ontology, also hierarchically
   // This implementation assumes that subjects are flat.
   // To support translations, multiple subj-groups can be provided with different xml:lang
-  let subjGroups = jats.findAll('article > front > article-meta > article-categories > subj-group');
+  const subjGroups = jats.findAll('article > front > article-meta > article-categories > subj-group');
   // TODO: get this from the article element
   const DEFAULT_LANG = 'en';
-  for (let subjGroup of subjGroups) {
-    let language = subjGroup.attr('xml:lang') || DEFAULT_LANG;
-    let subjectEls = subjGroup.findAll('subject');
-    for (let subjectEl of subjectEls) {
-      let subject = doc.create({
+  for (const subjGroup of subjGroups) {
+    const language = subjGroup.attr('xml:lang') || DEFAULT_LANG;
+    const groupType = subjGroup.attr('subj-group-type');
+    const subjectEls = subjGroup.findAll('subject');
+    for (const subjectEl of subjectEls) {
+      const subject = doc.create({
         type: 'subject',
         name: subjectEl.textContent,
         category: subjectEl.getAttribute('content-type'),
+        groupType,
         language,
       });
       documentHelpers.append(doc, ['metadata', 'subjects'], subject.id);
@@ -296,8 +299,8 @@ function _populateSubjects(doc, jats) {
 }
 
 function _populateTitle(doc, jats, jatsImporter) {
-  let article = doc.get('article');
-  let titleEl = jats.find('article > front > article-meta > title-group > article-title');
+  const article = doc.get('article');
+  const titleEl = jats.find('article > front > article-meta > title-group > article-title');
   if (titleEl) {
     article.title = jatsImporter.annotatedText(titleEl, ['article', 'title']);
   }
@@ -319,22 +322,22 @@ function _populateTitle(doc, jats, jatsImporter) {
 }
 
 function _populateSubTitle(doc, jats, jatsImporter) {
-  let article = doc.get('article');
-  let subTitleEl = jats.find('article > front > article-meta > title-group > subtitle');
+  const article = doc.get('article');
+  const subTitleEl = jats.find('article > front > article-meta > title-group > subtitle');
   if (subTitleEl) {
     article.subTitle = jatsImporter.annotatedText(subTitleEl, ['article', 'subTitle']);
   }
 }
 
 function _populateAbstract(doc, jats, jatsImporter) {
-  let $$ = jats.createElement.bind(jats);
-  let sectionContainerConverter = new SectionContainerConverter();
+  const $$ = jats.createElement.bind(jats);
+  const sectionContainerConverter = new SectionContainerConverter();
 
   // NOTE: The first abstract without abstract-type is used as main abstract,
   // if there are others they should be imported as a custom abstract
   // as well as abstracts with abstract-type attribute
-  let mainAbstract = doc.get('abstract');
-  let abstractEls = jats.findAll('article > front > article-meta > abstract');
+  const mainAbstract = doc.get('abstract');
+  const abstractEls = jats.findAll('article > front > article-meta > abstract');
   let mainAbstractImported = false;
   abstractEls.forEach(abstractEl => {
     const titleEl = findChild(abstractEl, 'title');
@@ -350,7 +353,7 @@ function _populateAbstract(doc, jats, jatsImporter) {
       sectionContainerConverter.import(abstractEl, mainAbstract, jatsImporter);
       mainAbstractImported = true;
     } else {
-      let abstract = doc.create({
+      const abstract = doc.create({
         type: 'custom-abstract',
         id: abstractEl.id,
         abstractType: abstractType,
@@ -382,10 +385,10 @@ function _populateAbstract(doc, jats, jatsImporter) {
 }
 
 function _populateAcknowledgements(doc, jats, jatsImporter) {
-  let $$ = jats.createElement.bind(jats);
-  let sectionContainerConverter = new SectionContainerConverter();
+  const $$ = jats.createElement.bind(jats);
+  const sectionContainerConverter = new SectionContainerConverter();
 
-  let acknowledgments = jats.findAll('article > back > ack');
+  const acknowledgments = jats.findAll('article > back > ack');
   acknowledgments.forEach(acknowledgment => {
     // Need to remove the 'title' from the child nodes, otherwise it will appear inline with the main text of the
     // acknowledgement.
@@ -399,7 +402,7 @@ function _populateAcknowledgements(doc, jats, jatsImporter) {
       acknowledgment.append($$('p'));
     }
 
-    let node = doc.create({
+    const node = doc.create({
       type: 'acknowledgement',
       id: acknowledgment.id,
     });
@@ -413,21 +416,21 @@ function _populateAcknowledgements(doc, jats, jatsImporter) {
 }
 
 function _populateBody(doc, jats, jatsImporter) {
-  let $$ = jats.createElement.bind(jats);
+  const $$ = jats.createElement.bind(jats);
   // ATTENTION: JATS can have multiple abstracts
   // ATM we only take the first, loosing the others
-  let bodyEl = jats.find('article > body');
+  const bodyEl = jats.find('article > body');
   if (bodyEl) {
     // add an empty paragraph if the body is empty
     if (bodyEl.getChildCount() === 0) {
       bodyEl.append($$('p'));
     }
-    let body = doc.get('body');
+    const body = doc.get('body');
     // ATTENTION: because there is already a body node in the document, *the* body, with id 'body'
     // we must change the id of the body element so that it does not collide with the internal one
     bodyEl.id = uuid();
-    let tmp = jatsImporter.convertElement(bodyEl);
-    let ids = tmp.content.slice();
+    const tmp = jatsImporter.convertElement(bodyEl);
+    const ids = tmp.content.slice();
     tmp.content = [];
     body.content = ids;
     doc.delete(tmp);
@@ -435,9 +438,9 @@ function _populateBody(doc, jats, jatsImporter) {
 }
 
 function _populateFootnotes(doc, jats, jatsImporter) {
-  let $$ = jats.createElement.bind(jats);
-  let fnEls = jats.findAll('article > back > fn-group > fn');
-  let article = doc.get('article');
+  const $$ = jats.createElement.bind(jats);
+  const fnEls = jats.findAll('article > back > fn-group > fn');
+  const article = doc.get('article');
   article.footnotes = fnEls.map(fnEl => {
     // there must be at least one paragraph
     if (!fnEl.find('p')) {
@@ -449,10 +452,10 @@ function _populateFootnotes(doc, jats, jatsImporter) {
 
 function _populateReferences(doc, jats, jatsImporter) {
   // TODO: make sure that we only allow this place for references via restricting the TextureJATS schema
-  let refListEl = jats.find('article > back > ref-list');
+  const refListEl = jats.find('article > back > ref-list');
   if (refListEl) {
-    let article = doc.get('article');
-    let refEls = refListEl.findAll('ref');
+    const article = doc.get('article');
+    const refEls = refListEl.findAll('ref');
     article.references = refEls.map(refEl => jatsImporter.convertElement(refEl).id);
   }
 }

--- a/src/article/converter/jats/jats2internal.js
+++ b/src/article/converter/jats/jats2internal.js
@@ -248,7 +248,7 @@ function _populateKeywords(doc, jats, jatsImporter) {
   const kwdGroupEls = jats.findAll('article > front > article-meta > kwd-group');
   const kwdIds = [];
   for (const kwdGroup of kwdGroupEls) {
-    const kwdGroupType = kwdGroup.getAttribute('kwd-group-type');
+    const kwdGroupType = kwdGroup.getAttribute('kwd-group-type') || 'author-generated';
     const kwdEls = kwdGroup.findAll('kwd');
     for (const kwdEl of kwdEls) {
       const kwd = doc.create({

--- a/src/article/converter/jats/jats2internal.js
+++ b/src/article/converter/jats/jats2internal.js
@@ -192,6 +192,7 @@ function _populateArticleInfo(doc, jats, jatsImporter) {
   const articleMetaEl = articleEl.find('front > article-meta');
   const metadata = doc.get('metadata');
   Object.assign(metadata, {
+    doi: getText(articleMetaEl, 'article-id[pub-id-type=doi]'),
     articleType: articleEl.getAttribute('article-type') || '',
     elocationId: getText(articleMetaEl, 'elocation-id'),
     fpage: getText(articleMetaEl, 'fpage'),

--- a/src/article/converter/jats/jats2internal.js
+++ b/src/article/converter/jats/jats2internal.js
@@ -245,16 +245,22 @@ function _extractDate(el) {
 }
 
 function _populateKeywords(doc, jats, jatsImporter) {
-  const kwdEls = jats.findAll('article > front > article-meta > kwd-group > kwd');
-  const kwdIds = kwdEls.map(kwdEl => {
-    const kwd = doc.create({
-      type: 'keyword',
-      category: kwdEl.getAttribute('content-type'),
-      language: kwdEl.getParent().getAttribute('xml:lang'),
-    });
-    kwd.name = jatsImporter.annotatedText(kwdEl, [kwd.id, 'name']);
-    return kwd.id;
-  });
+  const kwdGroupEls = jats.findAll('article > front > article-meta > kwd-group');
+  const kwdIds = [];
+  for (const kwdGroup of kwdGroupEls) {
+    const kwdGroupType = kwdGroup.getAttribute('kwd-group-type');
+    const kwdEls = kwdGroup.findAll('kwd');
+    for (const kwdEl of kwdEls) {
+      const kwd = doc.create({
+        type: 'keyword',
+        groupType: kwdGroupType,
+        category: kwdEl.getAttribute('content-type'),
+        language: kwdEl.getParent().getAttribute('xml:lang'),
+      });
+      kwd.name = jatsImporter.annotatedText(kwdEl, [kwd.id, 'name']);
+      kwdIds.push(kwd.id);
+    }
+  }
   doc.get('metadata').keywords = kwdIds;
 }
 

--- a/src/article/converter/jats/jats2internal.js
+++ b/src/article/converter/jats/jats2internal.js
@@ -229,8 +229,6 @@ function _populateArticleInfo(doc, jats, jatsImporter) {
     });
     Object.assign(metadata, dates);
   }
-
-  console.log(metadata);
 }
 
 const DATE_TYPES_MAP = {

--- a/src/article/metadata/InplaceRefContribsEditor.js
+++ b/src/article/metadata/InplaceRefContribsEditor.js
@@ -59,7 +59,7 @@ class InplaceRefContribEditor extends NodeComponent {
             placeholder: this.getLabel('given-names'),
           }).addClass('sm-given-names'),
           $$(Button, {
-            icon: 'remove',
+            icon: 'trash',
             // TODO: do we need this ref?
           })
             .ref('remove-button')

--- a/src/article/nodes/Keyword.js
+++ b/src/article/nodes/Keyword.js
@@ -8,8 +8,8 @@ export default class Keyword extends DocumentNode {
   // }
 
   render(options = {}) {
-    let { category, name } = this;
-    let result = [name];
+    const { category, name } = this;
+    const result = [name];
     if (!options.short) {
       if (category) {
         result.push(', ', category);
@@ -21,6 +21,7 @@ export default class Keyword extends DocumentNode {
 
 Keyword.schema = {
   type: 'keyword',
+  groupType: STRING,
   name: TEXT(...RICH_TEXT_ANNOS),
   category: STRING,
 };

--- a/src/article/nodes/Metadata.js
+++ b/src/article/nodes/Metadata.js
@@ -27,4 +27,5 @@ Metadata.schema = {
   revRequestedDate: STRING,
   permission: CHILD('permission'),
   doi: STRING,
+  collectionDate: STRING,
 };

--- a/src/article/nodes/Metadata.js
+++ b/src/article/nodes/Metadata.js
@@ -26,4 +26,5 @@ Metadata.schema = {
   revReceivedDate: STRING,
   revRequestedDate: STRING,
   permission: CHILD('permission'),
+  doi: STRING,
 };

--- a/src/article/nodes/Subject.js
+++ b/src/article/nodes/Subject.js
@@ -7,8 +7,8 @@ export default class Subject extends DocumentNode {
   // }
 
   render(options = {}) {
-    let { category, name } = this;
-    let result = [name];
+    const { category, name } = this;
+    const result = [name];
     if (!options.short) {
       if (category) {
         result.push(', ', category);
@@ -19,6 +19,7 @@ export default class Subject extends DocumentNode {
 }
 Subject.schema = {
   type: 'subject',
+  groupType: STRING,
   name: STRING,
   category: STRING,
 };

--- a/src/article/shared/DropdownEditor.js
+++ b/src/article/shared/DropdownEditor.js
@@ -5,7 +5,7 @@ export default class DropdownEditor extends ValueComponent {
   render($$) {
     const model = this.props.model;
     const value = model.getValue();
-    let el = $$('div').addClass(this._getClassNames());
+    const el = $$('div').addClass(this._getClassNames());
 
     const dropdownSelector = $$('select')
       .ref('input')

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -147,5 +147,7 @@ export default {
     config.addLabel('article-information-label', 'Article Information');
     config.addLabel('article-information-subjects-label', 'Subjects');
     config.addLabel('article-information-type-label', 'Article Type');
+    config.addLabel('article-information-keywords-label', 'Keywords');
+    config.addLabel('article-information-research-organisms-label', 'Research Organisms');
   },
 };

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -21,6 +21,7 @@ import {
   InlineFormulaComponent,
   InlineGraphicComponent,
   ItalicComponent,
+  KeywordComponent,
   KeywordsListComponent,
   ListComponent,
   ListItemComponent,
@@ -68,6 +69,7 @@ export default {
     config.addComponent('inline-formula', InlineFormulaComponent);
     config.addComponent('inline-graphic', InlineGraphicComponent);
     config.addComponent('italic', ItalicComponent);
+    config.addComponent('keyword', KeywordComponent);
     config.addComponent('keywords-list', KeywordsListComponent);
     config.addComponent('list', ListComponent);
     config.addComponent('list-item', ListItemComponent);

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -21,7 +21,6 @@ import {
   InlineFormulaComponent,
   InlineGraphicComponent,
   ItalicComponent,
-  KeywordComponent,
   KeywordsListComponent,
   ListComponent,
   ListItemComponent,
@@ -69,7 +68,6 @@ export default {
     config.addComponent('inline-formula', InlineFormulaComponent);
     config.addComponent('inline-graphic', InlineGraphicComponent);
     config.addComponent('italic', ItalicComponent);
-    config.addComponent('keyword', KeywordComponent);
     config.addComponent('keywords-list', KeywordsListComponent);
     config.addComponent('list', ListComponent);
     config.addComponent('list-item', ListItemComponent);

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -153,6 +153,11 @@ export default {
     config.addLabel('article-information-type-label', 'Article Type');
     config.addLabel('article-information-keywords-label', 'Keywords');
     config.addLabel('article-information-research-organisms-label', 'Research Organisms');
+    config.addLabel('article-information-doi-label', 'Article DOI');
+    config.addLabel('article-information-elocation-id-label', 'eLocation ID');
+    config.addLabel('article-information-year-label', 'Year');
+    config.addLabel('article-information-volume-label', 'Volume');
+    config.addLabel('article-information-publish-date-label', 'Publish date');
 
     // Keywords
     config.addLabel('author-generated', 'Keywords');

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -29,6 +29,7 @@ import {
   ReferenceListComponent,
   RelatedArticlesListComponent,
   SectionLabel,
+  SubjectsListComponent,
   SubscriptComponent,
   SuperscriptComponent,
   TableComponent,
@@ -77,6 +78,7 @@ export default {
     config.addComponent('section-label', SectionLabel);
     config.addComponent('small-caps', AnnotationComponent);
     config.addComponent('strike-through', AnnotationComponent);
+    config.addComponent('subjects-list', SubjectsListComponent);
     config.addComponent('subscript', SubscriptComponent);
     config.addComponent('superscript', SuperscriptComponent);
     config.addComponent('table', TableComponent);
@@ -140,5 +142,8 @@ export default {
     // Author details
     config.addLabel('author-details-label', 'Author Information');
     config.addLabel('author-details-correspendance', 'Corresponding author');
+
+    // Article Information
+    config.addLabel('article-information-label', 'Article Information');
   },
 };

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -4,6 +4,7 @@ import {
   AbstractComponent,
   AcknowledgementComponent,
   AffiliationsListComponent,
+  ArticleInformationComponent,
   AuthorsListComponent,
   AuthorDetailsListComponent,
   BlockFormulaComponent,
@@ -49,6 +50,7 @@ export default {
     config.addComponent('abstract', AbstractComponent);
     config.addComponent('acknowledgement', AcknowledgementComponent);
     config.addComponent('affiliations-list', AffiliationsListComponent);
+    config.addComponent('article-information', ArticleInformationComponent);
     config.addComponent('authors-list', AuthorsListComponent);
     config.addComponent('author-details-list', AuthorDetailsListComponent);
     config.addComponent('bold', BoldComponent);

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -162,5 +162,9 @@ export default {
     // Keywords
     config.addLabel('author-generated', 'Keywords');
     config.addLabel('research-organism', 'Research organisms');
+
+    // Subjects
+    config.addLabel('select-subject', 'Select subject');
+    config.addLabel('select-heading', 'Select type');
   },
 };

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -145,5 +145,7 @@ export default {
 
     // Article Information
     config.addLabel('article-information-label', 'Article Information');
+    config.addLabel('article-information-subjects-label', 'Subjects');
+    config.addLabel('article-information-type-label', 'Article Type');
   },
 };

--- a/src/article/shared/ManuscriptContentPackage.js
+++ b/src/article/shared/ManuscriptContentPackage.js
@@ -21,6 +21,7 @@ import {
   InlineFormulaComponent,
   InlineGraphicComponent,
   ItalicComponent,
+  KeywordsListComponent,
   ListComponent,
   ListItemComponent,
   ManuscriptComponent,
@@ -67,6 +68,7 @@ export default {
     config.addComponent('inline-formula', InlineFormulaComponent);
     config.addComponent('inline-graphic', InlineGraphicComponent);
     config.addComponent('italic', ItalicComponent);
+    config.addComponent('keywords-list', KeywordsListComponent);
     config.addComponent('list', ListComponent);
     config.addComponent('list-item', ListItemComponent);
     config.addComponent('manuscript', ManuscriptComponent);
@@ -151,5 +153,9 @@ export default {
     config.addLabel('article-information-type-label', 'Article Type');
     config.addLabel('article-information-keywords-label', 'Keywords');
     config.addLabel('article-information-research-organisms-label', 'Research Organisms');
+
+    // Keywords
+    config.addLabel('author-generated', 'Keywords');
+    config.addLabel('research-organism', 'Research organisms');
   },
 };

--- a/src/article/styles/_article-information.css
+++ b/src/article/styles/_article-information.css
@@ -1,0 +1,10 @@
+.article-information-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.article-information-sub-container {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/article/styles/_index.css
+++ b/src/article/styles/_index.css
@@ -1,6 +1,7 @@
 @import './_abstract.css';
 @import './_acknowledgement.css';
 @import './_add-reference-workflow.css';
+@import './_article-information.css';
 @import './_affiliations-list.css';
 @import './_article-panel.css';
 @import './_author-details-list.css';

--- a/src/article/styles/_index.css
+++ b/src/article/styles/_index.css
@@ -28,6 +28,8 @@
 @import './_importer.css';
 @import './_inline-formula.css';
 @import './_inline-graphic.css';
+@import './_keyword.css';
+@import './_keywords-list.css';
 @import './_math.css';
 @import './_manuscript.css';
 @import './_manuscript-view.css';

--- a/src/article/styles/_index.css
+++ b/src/article/styles/_index.css
@@ -44,6 +44,8 @@
 @import './_ref-contrib-editor.css';
 @import './_related_articles_list.css';
 @import './_section-label.css';
+@import './_subject-editor.css';
+@import './_subjects-list.css';
 @import './_supplementary-file.css';
 @import './_table.css';
 @import './_table-figure.css';

--- a/src/article/styles/_keyword.css
+++ b/src/article/styles/_keyword.css
@@ -1,7 +1,7 @@
 .sc-keyword {
   display: flex;
   flex-direction: row;
-  margin-right: var(--t-default-spacing);
+  margin-right: var(--t-half-spacing);
 }
 
 .sc-keyword-border {

--- a/src/article/styles/_keyword.css
+++ b/src/article/styles/_keyword.css
@@ -1,0 +1,20 @@
+.sc-keyword {
+  display: flex;
+  flex-direction: row;
+  margin-right: var(--t-default-spacing);
+}
+
+.sc-keyword-border {
+  box-sizing: border-box;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+  padding: 0px 4px;
+}
+
+.sc-keyword * .se-input {
+  width: fit-content;
+}
+
+.sc-keyword > .sc-button {
+  margin-left: var(--t-button-padding);
+}

--- a/src/article/styles/_keywords-list.css
+++ b/src/article/styles/_keywords-list.css
@@ -1,0 +1,5 @@
+.sc-keywords-list {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}

--- a/src/article/styles/_subject-editor.css
+++ b/src/article/styles/_subject-editor.css
@@ -1,0 +1,3 @@
+.sc-dropdown-editor {
+  margin-right: var(--t-half-spacing);
+}

--- a/src/article/styles/_subjects-list.css
+++ b/src/article/styles/_subjects-list.css
@@ -1,0 +1,4 @@
+.sc-subjects-list {
+  display: flex;
+  flex-direction: row;
+}


### PR DESCRIPTION
## Why

As per the UX design, I've updated the main manuscript section to now display various bits of the article metadata in the main view.

## What

* Updated/modified the convertor to support pulling dates from the 'pub-date' element.
* Created new components for ArticleInformation, Keywords and Subjects.

 I've had to cut 'some' corners with the implementation, mostly around switching to using the 'history' element to determine dates to instead using the 'pub-date' elements instead. At some point I'll need to come back round to this, but for now it will work for eLife's short term goal.
The way dates are handled in the convertor needs reworking anyway, as the current internal model is too restrictive.
