### PR TITLE
fix: update article type constants

### DIFF
--- a/src/article/ArticleConstants.js
+++ b/src/article/ArticleConstants.js
@@ -62,7 +62,22 @@ export const ARTICLE_SUBJECTS = [
   'Structural Biology and Molecular Biophysics',
 ];
 
-export const ARTICLE_TYPES = ['Insight', 'Research article', 'Tools and resources', 'Short report', 'Editorial'];
+export const ARTICLE_TYPES = [
+  'Research Article',
+  'Short Report',
+  'Tools and Resources',
+  'Research Advance',
+  'Registered Report',
+  'Replication Study',
+  'Research Communication',
+  'Feature Article',
+  'Insight',
+  'Editorial',
+  'Correction',
+  'Retraction',
+  'Scientific Correspondence',
+  'Review Article',
+];
 
 export const INTERNAL_BIBR_TYPES_TO_JATS = Object.keys(JATS_BIBR_TYPES_TO_INTERNAL).reduce((map, jatsType) => {
   let internalType = JATS_BIBR_TYPES_TO_INTERNAL[jatsType];


### PR DESCRIPTION
## Why

New list of article type constants received from production team.

## What

Ensure that the article type drop down control has a complete list of options.
