### PR TITLE
fix: should not display empty figure permission component

### DIFF
--- a/src/article/components/FigurePermissionsComponent.js
+++ b/src/article/components/FigurePermissionsComponent.js
@@ -8,9 +8,9 @@ export default class FigurePermissionsComponent extends ValueComponent {
   }
 
   render($$) {
-    let items = this.props.model.getItems();
+    const items = this.props.model.getItems();
     const Button = this.getComponent('button');
-    let el = $$('div').addClass('sc-permissions');
+    const el = $$('div').addClass('sc-permissions');
 
     if (items.length > 0) {
       el.append(items.map(field => this._renderPermissionCard($$, field)));
@@ -28,7 +28,7 @@ export default class FigurePermissionsComponent extends ValueComponent {
   }
 
   _renderPermissionCard($$, node) {
-    let PermissionComponent = this.getComponent(node.type);
+    const PermissionComponent = this.getComponent(node.type);
     const el = $$('div')
       .addClass('sc-card')
       .attr('data-id', node.id)

--- a/src/article/converter/jats/FigurePanelConverter.js
+++ b/src/article/converter/jats/FigurePanelConverter.js
@@ -15,12 +15,12 @@ export default class FigurePanelConverter {
   }
 
   import(el, node, importer) {
-    let $$ = el.createElement.bind(el.getOwnerDocument());
-    let labelEl = findChild(el, 'label');
-    let contentEl = this._getContent(el);
-    let permissionsEl = findAllChildren(el, 'permissions');
+    const $$ = el.createElement.bind(el.getOwnerDocument());
+    const labelEl = findChild(el, 'label');
+    const contentEl = this._getContent(el);
+    const permissionsEl = findAllChildren(el, 'permissions');
     let captionEl = findChild(el, 'caption');
-    let doc = importer.getDocument();
+    const doc = importer.getDocument();
     // Preparations
     if (!captionEl) {
       captionEl = $$('caption');
@@ -53,24 +53,21 @@ export default class FigurePanelConverter {
     // Note: we are transforming capton content to legend property
     node.legend = captionEl.children.map(child => importer.convertElement(child).id);
 
-    // Get all the permissions elements, create new 'Permission' nodes and pack their ids into an array. Note that if
-    // there aren't any permissions elements, then we create one.
-    node.permissions = new Array();
+    // Get all the permissions elements, create new 'Permission' nodes and pack their ids into an array.
+    node.permissions = [];
     if (permissionsEl.length > 0) {
-      for (let element of permissionsEl) {
+      for (const element of permissionsEl) {
         node.permissions.push(importer.convertElement(element).id);
       }
-    } else {
-      node.permissions.push(doc.create({ type: 'permission' }).id);
     }
 
     // Custom Metadata Fields
-    let kwdGroupEls = el.findAll('kwd-group');
+    const kwdGroupEls = el.findAll('kwd-group');
     node.metadata = kwdGroupEls.map(kwdGroupEl => {
-      let kwdEls = kwdGroupEl.findAll('kwd');
-      let labelEl = kwdGroupEl.find('label');
-      let name = labelEl ? labelEl.textContent : '';
-      let value = kwdEls.map(kwdEl => kwdEl.textContent).join(', ');
+      const kwdEls = kwdGroupEl.findAll('kwd');
+      const labelEl = kwdGroupEl.find('label');
+      const name = labelEl ? labelEl.textContent : '';
+      const value = kwdEls.map(kwdEl => kwdEl.textContent).join(', ');
       return doc.create({
         type: MetadataField.type,
         name,
@@ -79,7 +76,7 @@ export default class FigurePanelConverter {
     });
 
     // Attribution
-    let attributionEl = findChild(el, 'attrib');
+    const attributionEl = findChild(el, 'attrib');
     if (attributionEl) {
       node.attribution = importer.annotatedText(attributionEl, [node.id, 'attribution']);
     }
@@ -90,16 +87,16 @@ export default class FigurePanelConverter {
   }
 
   export(node, el, exporter) {
-    let $$ = exporter.$$;
+    const $$ = exporter.$$;
     // ATTENTION: this helper retrieves the label from the state
-    let label = getLabel(node);
+    const label = getLabel(node);
     if (label) {
       el.append($$('label').text(label));
     }
     // Attention: <title> is part of the <caption>
     // Note: we are transforming the content of legend to <caption>
     if (node.title || node.legend) {
-      let content = node.resolve('legend');
+      const content = node.resolve('legend');
       let captionEl = $$('caption');
       if (content.length > 0) {
         captionEl.append(content.map(p => exporter.convertNode(p)));
@@ -122,9 +119,9 @@ export default class FigurePanelConverter {
 
     // Custom Metadata Fields
     if (node.metadata.length > 0) {
-      let kwdGroupEls = node.resolve('metadata').map(field => {
-        let kwdGroupEl = $$('kwd-group').append($$('label').text(field.name));
-        let kwdEls = field.value.split(',').map(str => {
+      const kwdGroupEls = node.resolve('metadata').map(field => {
+        const kwdGroupEl = $$('kwd-group').append($$('label').text(field.name));
+        const kwdEls = field.value.split(',').map(str => {
           return $$('kwd').text(str.trim());
         });
         kwdGroupEl.append(kwdEls);
@@ -138,9 +135,9 @@ export default class FigurePanelConverter {
 
     // TODO: This needs to be tested to ensure that the permissions are exported correctly as children of the 'fig'
     //       element and not packed into a container of sorts.
-    let permissions = node.resolve('permissions');
+    const permissions = node.resolve('permissions');
     if (permissions.length > 0) {
-      for (let permission of permissions) {
+      for (const permission of permissions) {
         el.append(exporter.convertNode(permission));
       }
     }
@@ -148,12 +145,12 @@ export default class FigurePanelConverter {
 
   // EXPERIMENTAL see comment above
   _unwrapDisplayElements(el) {
-    let children = el.getChildren();
-    let L = children.length;
+    const children = el.getChildren();
+    const L = children.length;
     for (let i = L - 1; i >= 0; i--) {
-      let child = children[i];
+      const child = children[i];
       if (child.is('p[specific-use="display-element-wrapper"]')) {
-        let children = child.getChildren();
+        const children = child.getChildren();
         if (children.length === 1) {
           el.replaceChild(child, children[0]);
         } else {
@@ -164,12 +161,12 @@ export default class FigurePanelConverter {
   }
 
   _wrapDisplayElements(el) {
-    let children = el.getChildren();
-    let L = children.length;
+    const children = el.getChildren();
+    const L = children.length;
     for (let i = L - 1; i >= 0; i--) {
-      let child = children[i];
+      const child = children[i];
       if (!child.is('p')) {
-        let p = el
+        const p = el
           .createElement('p')
           .attr('specific-use', 'display-element-wrapper')
           .append(child.clone(true));

--- a/src/article/styles/_figure.css
+++ b/src/article/styles/_figure.css
@@ -23,6 +23,10 @@
   font-size: var(--t-small-font-size);
 }
 
+.sc-figure .sc-permissions {
+  margin-top: var(--t-double-spacing);
+}
+
 .sc-figure .sc-permissions .sc-card:last-of-type {
   margin-bottom: var(--t-default-spacing);
 }


### PR DESCRIPTION
## Why

As per the design, no need to insert an empty element as there is an 'add' button.

## What

No longer insert an empty permission object if none were found during import, and also tweaked the style to better match the design.
