### PR TITLE
fix: element spacing in related articles section

### DIFF
--- a/src/article/components/ManuscriptComponent.js
+++ b/src/article/components/ManuscriptComponent.js
@@ -185,7 +185,7 @@ export default class ManuscriptComponent extends Component {
     el.append(
       $$(ManuscriptSection, {
         name: 'related-articles',
-        label: 'Related Articles',
+        label: this.getLabel('relatedArticleSectionTitle'),
         model: relatedArticlesModel,
         hideWhenEmpty: true,
       }).append(

--- a/src/article/components/RelatedArticleComponent.js
+++ b/src/article/components/RelatedArticleComponent.js
@@ -83,7 +83,7 @@ class RelatedArticleComponent extends NodeComponent {
       .append(
         $$('div')
           .addClass('se-label')
-          .append(this.getLabel('relatedArticle')),
+          .append(this.getLabel('relatedArticleItemTitle')),
       );
 
     el.append(

--- a/src/article/shared/EntityLabelsPackage.js
+++ b/src/article/shared/EntityLabelsPackage.js
@@ -226,7 +226,8 @@ export default {
     config.addLabel('fn', 'Footnote');
 
     // related article labels
-    config.addLabel('relatedArticle', 'Related Articles');
+    config.addLabel('relatedArticleSectionTitle', 'Related Articles');
+    config.addLabel('relatedArticleItemTitle', 'Related Article');
     config.addLabel('relatedArticleHref', 'Article DOI');
     config.addLabel('relatedArticleHrefPlaceholder', '10.7554/eLife.00000');
     config.addLabel('relatedArticleType', 'Link Type');

--- a/src/article/styles/_related_articles_list.css
+++ b/src/article/styles/_related_articles_list.css
@@ -1,3 +1,7 @@
+.sm-related-articles > .sc-related-articles-list > :first-child {
+  margin-top: var(--t-default-spacing);
+}
+
 .sc-card > .sc-related-article {
   padding-top: 0px;
 }


### PR DESCRIPTION
## Why

Element spacing was incorrect compared to design

## What

Correct the styling to reduce the margin between the section heading and start of the first card
