### PR TITLE
fix: footnotes should not display in article view

### DIFF
--- a/docs/TextureJATS.md
+++ b/docs/TextureJATS.md
@@ -128,7 +128,7 @@ id, xml:base
 </pre>
 **Contains**:
 <pre style="white-space:pre-wrap;">
-article-id*,article-categories?,title-group?,contrib-group*,aff*,pub-date*,volume?,issue?,issue-title?,isbn?,(((fpage,lpage?)?,page-range?)|elocation-id)?,history?,permissions?,related-article?,abstract*,trans-abstract*,kwd-group*,funding-group*
+article-id*,article-categories?,title-group?,contrib-group*,aff*,pub-date*,volume?,issue?,issue-title?,isbn?,(((fpage,lpage?)?,page-range?)|elocation-id)?,history?,permissions?,related-article?,author-notes?,abstract*,trans-abstract*,kwd-group*,funding-group*
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
@@ -163,6 +163,21 @@ id, xml:base, specific-use, xml:lang
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
 disp-quote
+</pre>
+
+### `<author-notes>`
+
+**Attributes**:
+<pre style="white-space:pre-wrap;">
+
+</pre>
+**Contains**:
+<pre style="white-space:pre-wrap;">
+fn*
+</pre>
+**This element may be contained in:**
+<pre style="white-space:pre-wrap;">
+article-meta
 </pre>
 
 ### `<award-group>`
@@ -747,7 +762,7 @@ label?,p+
 </pre>
 **This element may be contained in:**
 <pre style="white-space:pre-wrap;">
-fn-group
+author-notes, fn-group
 </pre>
 
 ### `<fn-group>`
@@ -2100,7 +2115,6 @@ element-citation, date, pub-date
 - app-group
 - array
 - author-comment
-- author-notes
 - boxed-text
 - chem-struct
 - chem-struct-wrap

--- a/src/article/ArticleLoader.js
+++ b/src/article/ArticleLoader.js
@@ -30,9 +30,14 @@ export default class ArticleLoader {
     if (validator) {
       let validationResult = validator.validate(xmlDom);
       if (!validationResult.ok) {
-        let err = new Error('Validation failed.');
-        err.detail = validationResult.errors;
-        throw err;
+        // FIXME: For now i've added a temp config key to disable strict behaviour, but this should be fixed up properly.
+        if (substanceGlobals.STRICT_VALIDATION !== undefined && substanceGlobals.STRICT_VALIDATION === false) {
+          console.warn(`Validation failed whilst loading the article, carrying on anyway...`);
+        } else {
+          let err = new Error('Validation failed.');
+          err.detail = validationResult.errors;
+          throw err;
+        }
       }
     }
 
@@ -48,7 +53,7 @@ export default class ArticleLoader {
       if (validator) {
         let validationResult = validator.validate(xmlDom);
         if (!validationResult.ok) {
-          // FIXME: For now i've added a temp condig key to disable strict behaviour, but this should be fixed up properly.
+          // FIXME: For now i've added a temp config key to disable strict behaviour, but this should be fixed up properly.
           if (substanceGlobals.STRICT_VALIDATION !== undefined && substanceGlobals.STRICT_VALIDATION === false) {
             console.warn(`Validation post transformation failed whilst loading the article, carrying on anyway...`);
           } else {

--- a/src/article/TextureJATS.rng
+++ b/src/article/TextureJATS.rng
@@ -23,7 +23,6 @@
   <s:not-implemented name="app-group"/>
   <s:not-implemented name="array"/>
   <s:not-implemented name="author-comment"/>
-  <s:not-implemented name="author-notes"/>
   <s:not-implemented name="boxed-text"/>
   <s:not-implemented name="chem-struct"/>
   <s:not-implemented name="chem-struct-wrap"/>
@@ -43,7 +42,7 @@
   <s:not-implemented name="corresp"/>
   <s:not-implemented name="count"/>
   <s:not-implemented name="counts"/>
-  <s:not-implemented name="custom-meta"/>
+  <s:not-implemented name="custom-meta"/> 
   <s:not-implemented name="custom-meta-group"/>
   <s:not-implemented name="def"/>
   <s:not-implemented name="def-head"/>
@@ -442,6 +441,9 @@
       <optional>
         <ref name="related-article"/>
       </optional>
+      <optional>
+        <ref name="author-notes"/>
+      </optional>
       <zeroOrMore>
         <ref name="abstract"/>
       </zeroOrMore>
@@ -500,6 +502,14 @@
       <ref name="article-categories-attlist"/>
       <zeroOrMore>
         <ref name="subj-group"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="author-notes">
+    <element name="author-notes">
+      <zeroOrMore>
+        <ref name="fn"/>
       </zeroOrMore>
     </element>
   </define>

--- a/src/article/api/ArticleAPI.js
+++ b/src/article/api/ArticleAPI.js
@@ -32,7 +32,6 @@ import {
   TableFigure,
   InlineGraphic,
   BlockQuote,
-  Box,
   Person,
   Affiliation,
   CustomAbstract,
@@ -47,7 +46,7 @@ const DISALLOWED_MANIPULATION = 'Manipulation is not allowed.';
 
 export default class ArticleAPI {
   constructor(editorSession, archive, config) {
-    let doc = editorSession.getDocument();
+    const doc = editorSession.getDocument();
 
     this.editorSession = editorSession;
     this.config = config;
@@ -120,11 +119,11 @@ export default class ArticleAPI {
     // to replicate it, currently only for metadata fields
     const panelTemplate = figure.getTemplateFromCurrentPanel();
     this.editorSession.transaction(tx => {
-      let template = FigurePanel.getTemplate();
+      const template = FigurePanel.getTemplate();
       template.content.href = href;
       template.content.mimeType = file.type;
       Object.assign(template, panelTemplate);
-      let node = documentHelpers.createNodeFromJson(tx, template);
+      const node = documentHelpers.createNodeFromJson(tx, template);
       documentHelpers.insertAt(tx, [figure.id, 'panels'], insertPos, node.id);
       tx.set([figure.id, 'state', 'currentPanelIndex'], insertPos);
     });
@@ -132,11 +131,11 @@ export default class ArticleAPI {
 
   // TODO: it is not so common to add footnotes without an xref in the text
   addFootnote(footnoteCollectionPath) {
-    let editorSession = this.getEditorSession();
+    const editorSession = this.getEditorSession();
     editorSession.transaction(tx => {
-      let node = documentHelpers.createNodeFromJson(tx, Footnote.getTemplate());
+      const node = documentHelpers.createNodeFromJson(tx, Footnote.getTemplate());
       documentHelpers.append(tx, footnoteCollectionPath, node.id);
-      let p = tx.get(node.content[0]);
+      const p = tx.get(node.content[0]);
       tx.setSelection({
         type: 'property',
         path: p.getPath(),
@@ -152,21 +151,21 @@ export default class ArticleAPI {
   }
 
   addReferences(refsData) {
-    let editorSession = this.getEditorSession();
+    const editorSession = this.getEditorSession();
     editorSession.transaction(tx => {
-      let refNodes = refsData.map(refData => documentHelpers.createNodeFromJson(tx, refData));
+      const refNodes = refsData.map(refData => documentHelpers.createNodeFromJson(tx, refData));
       refNodes.forEach(ref => {
         documentHelpers.append(tx, ['article', 'references'], ref.id);
       });
       if (refNodes.length > 0) {
-        let newSelection = this._createEntitySelection(refNodes[0]);
+        const newSelection = this._createEntitySelection(refNodes[0]);
         tx.setSelection(newSelection);
       }
     });
   }
 
   canCreateAnnotation(annoType) {
-    let editorState = this.getEditorState();
+    const editorState = this.getEditorState();
     const sel = editorState.selection;
     const selectionState = editorState.selectionState;
     if (
@@ -177,7 +176,7 @@ export default class ArticleAPI {
       selectionState.property.targetTypes.has(annoType)
     ) {
       // otherwise these annos are only allowed to 'touch' the current selection, not overlap.
-      for (let anno of selectionState.annos) {
+      for (const anno of selectionState.annos) {
         if (sel.overlaps(anno.getSelection(), 'strict')) return false;
       }
       return true;
@@ -190,12 +189,12 @@ export default class ArticleAPI {
   }
 
   canInsertBlockNode(nodeType) {
-    let editorState = this.getEditorState();
-    let doc = editorState.document;
-    let sel = editorState.selection;
-    let selState = editorState.selectionState;
+    const editorState = this.getEditorState();
+    const doc = editorState.document;
+    const sel = editorState.selection;
+    const selState = editorState.selectionState;
     if (sel && !sel.isNull() && !sel.isCustomSelection() && sel.isCollapsed() && selState.containerPath) {
-      let containerProp = doc.getProperty(selState.containerPath);
+      const containerProp = doc.getProperty(selState.containerPath);
       if (containerProp.targetTypes.has(nodeType)) {
         return true;
       }
@@ -218,12 +217,12 @@ export default class ArticleAPI {
    * @param {boolean} collapsedOnly true if insertion is allowed only for collapsed selection
    */
   canInsertInlineNode(type, collapsedOnly) {
-    let editorState = this.getEditorState();
+    const editorState = this.getEditorState();
     const sel = editorState.selection;
     const selectionState = editorState.selectionState;
     if (sel && !sel.isNull() && sel.isPropertySelection() && (!collapsedOnly || sel.isCollapsed())) {
       // make sure that the schema allows to insert that node
-      let targetTypes = selectionState.property.targetTypes;
+      const targetTypes = selectionState.property.targetTypes;
       if (targetTypes.size > 0 && targetTypes.has(type)) {
         return true;
       }
@@ -232,23 +231,23 @@ export default class ArticleAPI {
   }
 
   canMoveEntityUp(nodeId) {
-    let node = this._getNode(nodeId);
+    const node = this._getNode(nodeId);
     if (node && this._isCollectionItem(node) && !this._isManagedCollectionItem(node)) {
       return node.getPosition() > 0;
     }
   }
 
   canMoveEntityDown(nodeId) {
-    let node = this._getNode(nodeId);
+    const node = this._getNode(nodeId);
     if (node && this._isCollectionItem(node) && !this._isManagedCollectionItem(node)) {
-      let pos = node.getPosition();
-      let ids = this.getDocument().get(this._getCollectionPathForItem(node));
+      const pos = node.getPosition();
+      const ids = this.getDocument().get(this._getCollectionPathForItem(node));
       return pos < ids.length - 1;
     }
   }
 
   canRemoveEntity(nodeId) {
-    let node = this._getNode(nodeId);
+    const node = this._getNode(nodeId);
     if (node) {
       return this._isCollectionItem(node);
     } else {
@@ -265,7 +264,7 @@ export default class ArticleAPI {
   }
 
   dedent() {
-    let editorSession = this.getEditorSession();
+    const editorSession = this.getEditorSession();
     editorSession.transaction(tx => {
       tx.dedent();
     });
@@ -284,8 +283,8 @@ export default class ArticleAPI {
   }
 
   focusEditor(path) {
-    let editorSession = this.getEditorSession();
-    let surface = editorSession.getSurfaceForProperty(path);
+    const editorSession = this.getEditorSession();
+    const surface = editorSession.getSurfaceForProperty(path);
     if (surface) {
       surface.selectFirst();
     }
@@ -326,9 +325,9 @@ export default class ArticleAPI {
     }
     let valueModel = this._valueModelCache.get(propKey);
     if (!valueModel) {
-      let doc = this.getDocument();
-      let path = propKey.split('.');
-      let prop = doc.getProperty(path);
+      const doc = this.getDocument();
+      const path = propKey.split('.');
+      const prop = doc.getProperty(path);
       if (!prop) throw new Error('Property does not exist');
       valueModel = createValueModel(this, path, prop);
     }
@@ -343,7 +342,7 @@ export default class ArticleAPI {
   }
 
   indent() {
-    let editorSession = this.getEditorSession();
+    const editorSession = this.getEditorSession();
     editorSession.transaction(tx => {
       tx.indent();
     });
@@ -357,7 +356,7 @@ export default class ArticleAPI {
   }
 
   insertBlockNode(nodeData) {
-    let nodeId = this._insertBlockNode(tx => {
+    const nodeId = this._insertBlockNode(tx => {
       return documentHelpers.createNodeFromJson(tx, nodeData);
     });
     return this.getDocument().get(nodeId);
@@ -378,9 +377,9 @@ export default class ArticleAPI {
   insertFootnoteReference() {
     if (!this.canInsertCrossReference()) throw new Error(DISALLOWED_MANIPULATION);
     // In table-figures we want to allow only cross-reference to table-footnotes
-    let selectionState = this.getEditorState().selectionState;
+    const selectionState = this.getEditorState().selectionState;
     const xpath = selectionState.xpath;
-    let refType = xpath.find(n => n.type === TableFigure.type) ? 'table-fn' : 'fn';
+    const refType = xpath.find(n => n.type === TableFigure.type) ? 'table-fn' : 'fn';
     return this._insertCrossReference(refType);
   }
 
@@ -391,10 +390,10 @@ export default class ArticleAPI {
     // This way the archive gets 'polluted', i.e. a redo of that change does
     // not remove the asset.
     const editorSession = this.getEditorSession();
-    let paths = files.map(file => {
+    const paths = files.map(file => {
       return this.archive.addAsset(file);
     });
-    let sel = editorSession.getSelection();
+    const sel = editorSession.getSelection();
     if (!sel || !sel.containerPath) return;
     editorSession.transaction(tx => {
       importFigures(tx, sel, files, paths);
@@ -402,7 +401,7 @@ export default class ArticleAPI {
   }
 
   insertInlineNode(nodeData) {
-    let nodeId = this._insertInlineNode(tx => {
+    const nodeId = this._insertInlineNode(tx => {
       return documentHelpers.createNodeFromJson(tx, nodeData);
     });
     return this.getDocument().get(nodeId);
@@ -435,14 +434,14 @@ export default class ArticleAPI {
   insertSupplementaryFile(file, url) {
     const articleSession = this.editorSession;
     if (file) url = this.archive.addAsset(file);
-    let sel = articleSession.getSelection();
+    const sel = articleSession.getSelection();
     articleSession.transaction(tx => {
-      let containerPath = sel.containerPath;
-      let nodeData = SupplementaryFile.getTemplate();
+      const containerPath = sel.containerPath;
+      const nodeData = SupplementaryFile.getTemplate();
       nodeData.mimetype = file ? file.type : '';
       nodeData.href = url;
       nodeData.remote = !file;
-      let supplementaryFile = documentHelpers.createNodeFromJson(tx, nodeData);
+      const supplementaryFile = documentHelpers.createNodeFromJson(tx, nodeData);
       tx.insertBlockNode(supplementaryFile);
       selectionHelpers.selectNode(tx, supplementaryFile.id, containerPath);
     });
@@ -475,23 +474,23 @@ export default class ArticleAPI {
 
   removeEntity(nodeId) {
     if (!this.canRemoveEntity(nodeId)) throw new Error(DISALLOWED_MANIPULATION);
-    let node = this._getNode(nodeId);
+    const node = this._getNode(nodeId);
     if (!node) throw new Error('Invalid argument.');
-    let collectionPath = this._getCollectionPathForItem(node);
+    const collectionPath = this._getCollectionPathForItem(node);
     this._removeItemFromCollection(nodeId, collectionPath);
   }
 
   removeFootnote(footnoteId) {
     // ATTENTION: footnotes appear in different contexts
     // e.g. article.footnotes, or table-fig.footnotes
-    let doc = this.getDocument();
-    let footnote = doc.get(footnoteId);
-    let parent = footnote.getParent();
+    const doc = this.getDocument();
+    const footnote = doc.get(footnoteId);
+    const parent = footnote.getParent();
     this._removeItemFromCollection(footnoteId, [parent.id, 'footnotes']);
   }
 
   renderEntity(entity, options) {
-    let exporter = this.config.createExporter('html');
+    const exporter = this.config.createExporter('html');
     return renderEntity(entity, exporter);
   }
 
@@ -504,7 +503,7 @@ export default class ArticleAPI {
   }
 
   selectNode(nodeId) {
-    let selData = this._createNodeSelection(nodeId);
+    const selData = this._createNodeSelection(nodeId);
     if (selData) {
       this.editorSession.setSelection(selData);
     }
@@ -529,7 +528,7 @@ export default class ArticleAPI {
 
   switchFigurePanel(figure, newPanelIndex) {
     const editorSession = this.editorSession;
-    let sel = editorSession.getSelection();
+    const sel = editorSession.getSelection();
     if (!sel.isNodeSelection() || sel.getNodeId() !== figure.id) {
       this.selectNode(figure.id);
     }
@@ -542,7 +541,7 @@ export default class ArticleAPI {
       createNode = tx => tx.create({ type });
     }
     editorSession.transaction(tx => {
-      let node = createNode(tx);
+      const node = createNode(tx);
       documentHelpers.append(tx, collectionPath, node.id);
       tx.setSelection(this._createEntitySelection(node));
     });
@@ -551,18 +550,18 @@ export default class ArticleAPI {
   // This is used by CollectionModel
   _appendChild(collectionPath, data) {
     this.editorSession.transaction(tx => {
-      let node = tx.create(data);
+      const node = tx.create(data);
       documentHelpers.append(tx, collectionPath, node.id);
     });
   }
 
   _createNodeSelection(nodeId) {
-    let editorState = this.getEditorState();
-    let doc = editorState.document;
+    const editorState = this.getEditorState();
+    const doc = editorState.document;
     const node = doc.get(nodeId);
     if (node) {
-      let editorSession = this.getEditorSession();
-      let sel = editorState.selection;
+      const editorSession = this.getEditorSession();
+      const sel = editorState.selection;
       const containerPath = this._getContainerPathForNode(node);
       const surface = editorSession.surfaceManager._getSurfaceForProperty(containerPath);
       const surfaceId = surface ? surface.getId() : sel ? sel.surfaceId : null;
@@ -641,13 +640,13 @@ export default class ArticleAPI {
   // Instead we could use dedicated Components derived from the ones from the kit
   // and use specific API to accomplish this
   _getAvailableOptions(model) {
-    let targetTypes = Array.from(model._targetTypes);
+    const targetTypes = Array.from(model._targetTypes);
     if (targetTypes.length !== 1) {
       throw new Error('Unsupported relationship. Expected to find one targetType');
     }
-    let doc = this.getDocument();
-    let first = targetTypes[0];
-    let targetType = first;
+    const doc = this.getDocument();
+    const first = targetTypes[0];
+    const targetType = first;
     switch (targetType) {
       case 'funder': {
         return doc.get('metadata').resolve('funders');
@@ -658,8 +657,8 @@ export default class ArticleAPI {
       case 'group': {
         return doc.get('metadata').resolve('groups');
       }
-      case 'footnote': {
-        return doc.get('article').resolve('footnotes');
+      case 'conflict-of-interest': {
+        return doc.get('article').resolve('conflictOfInterests');
       }
       default:
         throw new Error('Unsupported relationship: ' + targetType);
@@ -668,7 +667,7 @@ export default class ArticleAPI {
 
   // TODO: how could we make this extensible via plugins?
   _getAvailableXrefTargets(xref) {
-    let refType = xref.refType;
+    const refType = xref.refType;
     let manager;
     switch (refType) {
       case BlockFormula.refType: {
@@ -682,7 +681,7 @@ export default class ArticleAPI {
       case 'fn': {
         // EXPERIMENTAL: table footnotes
         // TableFootnoteManager is stored on the TableFigure instance
-        let tableFigure = findParentByType(xref, 'table-figure');
+        const tableFigure = findParentByType(xref, 'table-figure');
         if (tableFigure) {
           manager = tableFigure.getFootnoteManager();
         } else {
@@ -691,7 +690,7 @@ export default class ArticleAPI {
         break;
       }
       case 'table-fn': {
-        let tableFigure = findParentByType(xref, 'table-figure');
+        const tableFigure = findParentByType(xref, 'table-figure');
         if (tableFigure) {
           manager = tableFigure.getFootnoteManager();
         }
@@ -714,11 +713,11 @@ export default class ArticleAPI {
     }
     if (!manager) return [];
 
-    let selectedTargets = xref.resolve('refTargets');
+    const selectedTargets = xref.resolve('refTargets');
     // retrieve all possible nodes that this
     // xref could potentially point to,
     // so that we can let the user select from a list.
-    let availableTargets = manager.getSortedCitables();
+    const availableTargets = manager.getSortedCitables();
     let targets = availableTargets.map(target => {
       // ATTENTION: targets are not just nodes
       // but entries with some information
@@ -729,7 +728,7 @@ export default class ArticleAPI {
       };
     });
     // Determine broken targets (such that don't exist in the document)
-    let brokenTargets = without(selectedTargets, ...availableTargets);
+    const brokenTargets = without(selectedTargets, ...availableTargets);
     if (brokenTargets.length > 0) {
       targets = targets.concat(
         brokenTargets.map(id => {
@@ -743,11 +742,11 @@ export default class ArticleAPI {
   }
 
   _getCollectionPathForItem(node) {
-    let parent = node.getParent();
-    let propName = node.getXpath().property;
+    const parent = node.getParent();
+    const propName = node.getXpath().property;
     if (parent && propName) {
-      let collectionPath = [parent.id, propName];
-      let property = node.getDocument().getProperty(collectionPath);
+      const collectionPath = [parent.id, propName];
+      const property = node.getDocument().getProperty(collectionPath);
       if (property.isArray() && property.isReference()) {
         return collectionPath;
       }
@@ -755,9 +754,9 @@ export default class ArticleAPI {
   }
 
   _getContainerPathForNode(node) {
-    let last = node.getXpath();
-    let prop = last.property;
-    let prev = last.prev;
+    const last = node.getXpath();
+    const prop = last.property;
+    const prev = last.prev;
     if (prev && prop) {
       return [prev.id, prop];
     }
@@ -767,8 +766,8 @@ export default class ArticleAPI {
     // TODO: still not sure if this is the right approach
     // Maybe it would be simpler to just use configuration
     // and fall back to 'node' or 'card' selection otherwise
-    let schema = node.getSchema();
-    for (let p of schema) {
+    const schema = node.getSchema();
+    for (const p of schema) {
       if (p.name === 'id' || !this._isFieldRequired([node.type, p.name])) continue;
       return p;
     }
@@ -782,8 +781,8 @@ export default class ArticleAPI {
   // exploiting knowledge about the implemented view structure
   // in manuscript it is either top-level (e.g. title, abstract) or part of a container (body)
   _getSurfaceId(node, propertyName) {
-    let xpath = node.getXpath().toArray();
-    let idx = xpath.findIndex(entry => entry.id === 'body');
+    const xpath = node.getXpath().toArray();
+    const idx = xpath.findIndex(entry => entry.id === 'body');
     let relXpath;
     if (idx >= 0) {
       relXpath = xpath.slice(idx);
@@ -795,10 +794,10 @@ export default class ArticleAPI {
   }
 
   _insertBlockNode(createNode) {
-    let editorSession = this.getEditorSession();
+    const editorSession = this.getEditorSession();
     let nodeId;
     editorSession.transaction(tx => {
-      let node = createNode(tx);
+      const node = createNode(tx);
       tx.insertBlockNode(node);
       tx.setSelection(this._createNodeSelection(node));
       nodeId = node.id;
@@ -816,10 +815,10 @@ export default class ArticleAPI {
   }
 
   _insertInlineNode(createNode) {
-    let editorSession = this.getEditorSession();
+    const editorSession = this.getEditorSession();
     let nodeId;
     editorSession.transaction(tx => {
-      let inlineNode = createNode(tx);
+      const inlineNode = createNode(tx);
       tx.insertInlineNode(inlineNode);
       // TODO: some inline nodes have an input field
       // which we might want to focus initially
@@ -836,8 +835,8 @@ export default class ArticleAPI {
 
   _isFieldRequired(path) {
     // ATTENTION: this API is experimental
-    let settings = this.getEditorState().settings;
-    let valueSettings = settings.getSettingsForValue(path);
+    const settings = this.getEditorState().settings;
+    const valueSettings = settings.getSettingsForValue(path);
     return Boolean(valueSettings['required']);
   }
 
@@ -848,16 +847,16 @@ export default class ArticleAPI {
 
   // TODO: we need a better way to update settings
   _loadSettings(settings) {
-    let editorState = this.getContext().editorState;
+    const editorState = this.getContext().editorState;
     editorState.settings.load(settings);
     editorState._setDirty('settings');
     editorState.propagateUpdates();
   }
 
   _moveEntity(nodeId, shift) {
-    let node = this._getNode(nodeId);
+    const node = this._getNode(nodeId);
     if (!node) throw new Error('Invalid argument.');
-    let collectionPath = this._getCollectionPathForItem(node);
+    const collectionPath = this._getCollectionPathForItem(node);
     this._moveChild(collectionPath, nodeId, shift);
   }
 
@@ -869,8 +868,8 @@ export default class ArticleAPI {
   // from EditorSession logic
   _moveChild(collectionPath, childId, shift, txHook) {
     this.editorSession.transaction(tx => {
-      let ids = tx.get(collectionPath);
-      let pos = ids.indexOf(childId);
+      const ids = tx.get(collectionPath);
+      const pos = ids.indexOf(childId);
       if (pos === -1) return;
       documentHelpers.removeAt(tx, collectionPath, pos);
       documentHelpers.insertAt(tx, collectionPath, pos + shift, childId);
@@ -907,7 +906,7 @@ export default class ArticleAPI {
   _removeItemFromCollection(itemId, collectionPath) {
     const editorSession = this.getEditorSession();
     editorSession.transaction(tx => {
-      let item = tx.get(itemId);
+      const item = tx.get(itemId);
       documentHelpers.removeFromCollection(tx, collectionPath, itemId);
       // TODO: discuss if we really should do this, or want to do something different.
       this._removeCorrespondingXrefs(tx, item);
@@ -942,8 +941,8 @@ export default class ArticleAPI {
 
   _toggleRelationship(path, id) {
     this.editorSession.transaction(tx => {
-      let ids = tx.get(path);
-      let idx = ids.indexOf(id);
+      const ids = tx.get(path);
+      const idx = ids.indexOf(id);
       if (idx === -1) {
         tx.update(path, { type: 'insert', pos: ids.length, value: id });
       } else {
@@ -954,8 +953,8 @@ export default class ArticleAPI {
   }
 
   _toggleXrefTarget(xref, targetId) {
-    let targetIds = xref.refTargets;
-    let index = targetIds.indexOf(targetId);
+    const targetIds = xref.refTargets;
+    const index = targetIds.indexOf(targetId);
     if (index >= 0) {
       this.editorSession.transaction(tx => {
         tx.update([xref.id, 'refTargets'], { type: 'delete', pos: index });

--- a/src/article/api/ArticleAPI.js
+++ b/src/article/api/ArticleAPI.js
@@ -658,6 +658,9 @@ export default class ArticleAPI {
       case 'group': {
         return doc.get('metadata').resolve('groups');
       }
+      case 'footnote': {
+        return doc.get('article').resolve('footnotes');
+      }
       default:
         throw new Error('Unsupported relationship: ' + targetType);
     }

--- a/src/article/api/ArticleModel.js
+++ b/src/article/api/ArticleModel.js
@@ -37,6 +37,14 @@ export default class ArticleModel extends Model {
     return this.getFootnotes().length > 0;
   }
 
+  getConflictOfInterests() {
+    return this._getValueModel('article.conflictOfInterests');
+  }
+
+  hasConflictOfInterests() {
+    return this.getConflictOfInterests().length > 0;
+  }
+
   getKeywords() {
     return this._getValueModel('metadata.keywords');
   }

--- a/src/article/components/AuthorDetailsListComponent.js
+++ b/src/article/components/AuthorDetailsListComponent.js
@@ -69,8 +69,8 @@ class AuthorDetailsDisplay extends NodeComponent {
       el.append(this._renderAffiliations($$, author));
     }
 
-    if (author.competingInterests.length > 0) {
-      el.append(this._renderCompetingInterests($$, author));
+    if (author.conflictOfInterests.length > 0) {
+      el.append(this._renderConflictOfInterests($$, author));
     }
 
     return el;
@@ -148,9 +148,9 @@ class AuthorDetailsDisplay extends NodeComponent {
     }, []);
   }
 
-  _renderCompetingInterests($$, author) {
+  _renderConflictOfInterests($$, author) {
     const doc = author.document;
-    const competingInterests = author.competingInterests.reduce((elements, id) => {
+    const competingInterests = author.conflictOfInterests.reduce((elements, id) => {
       const element = doc.get(id);
       if (element) {
         elements.push($$(FootnoteComponent, { node: element, mode: CONTENT_MODE }));

--- a/src/article/components/FootnoteComponent.js
+++ b/src/article/components/FootnoteComponent.js
@@ -13,9 +13,9 @@ export default class FootnoteComponent extends NodeComponent {
     }
 
     const footnote = this.props.node;
-    let label = getLabel(footnote) || '?';
+    const label = getLabel(footnote) || '?';
 
-    let el = $$('div')
+    const el = $$('div')
       .addClass('sc-footnote')
       .attr('data-id', footnote.id);
     el.append(
@@ -32,12 +32,12 @@ export default class FootnoteComponent extends NodeComponent {
   }
 
   _renderPreviewVersion($$) {
-    let footnote = this.props.node;
-    let el = $$('div')
+    const footnote = this.props.node;
+    const el = $$('div')
       .addClass('sc-footnote')
       .attr('data-id', footnote.id);
 
-    let label = getLabel(footnote) || '?';
+    const label = getLabel(footnote) || '?';
     el.append(
       $$(PreviewComponent, {
         id: footnote.id,

--- a/src/article/components/FootnoteEditor.js
+++ b/src/article/components/FootnoteEditor.js
@@ -11,7 +11,7 @@ export default class FootnoteEditor extends ValueComponent {
 
   _renderFootnotes($$) {
     const model = this.props.model;
-    let items = model.getItems();
+    const items = model.getItems();
     return items.map(item => $$(FootnoteComponent, { node: item }).ref(item.id));
   }
 }

--- a/src/article/converter/jats/FootnoteConverter.js
+++ b/src/article/converter/jats/FootnoteConverter.js
@@ -14,7 +14,9 @@ export default class FootnoteConverter {
 
   // NOTE: we don’t support custom labels at the moment, so we will ignore input from fn > label
   import(el, node, importer) {
-    let pEls = findAllChildren(el, 'p');
+    const type = el.attr('fn-type') || '';
+    const pEls = findAllChildren(el, 'p');
+    node.footnoteType = type;
     node.content = pEls.map(el => importer.convertElement(el).id);
   }
 
@@ -25,9 +27,12 @@ export default class FootnoteConverter {
     // or they are generated without persisting operations (e.g. think about undo/redo, or collab)
     // my suggestion would be to introduce volatile ops, they would be excluded from the DocumentChange, that is stored in the change history,
     // or used for collaborative editing.
-    let label = getLabel(node);
+    const label = getLabel(node);
     if (label) {
       el.append($$('label').text(label));
+    }
+    if (node.footnoteType) {
+      el.attr('fn-type', node.footnoteType);
     }
     el.append(node.resolve('content').map(p => exporter.convertNode(p)));
   }

--- a/src/article/converter/jats/internal2jats.js
+++ b/src/article/converter/jats/internal2jats.js
@@ -566,7 +566,10 @@ function _populateBack(jats, doc, jatsExporter) {
       ref-list?,
     )
   */
-  const footnotes = doc.resolve(['article', 'footnotes']);
+
+  // NOTE: Conflicts of Interest are a specific type of footnote, we just handle them internally as a seperate entity,
+  //       hence here we need to combine both footnotes and COI-statements and write them out as a singular group.
+  const footnotes = [...doc.resolve(['article', 'footnotes']), ...doc.resolve(['article', 'conflictOfInterests'])];
   if (footnotes.length > 0) {
     backEl.append(
       $$('fn-group').append(

--- a/src/article/converter/jats/internal2jats.js
+++ b/src/article/converter/jats/internal2jats.js
@@ -57,7 +57,17 @@ function _populateArticleMeta(jats, doc, jatsExporter) {
   // aff*
   articleMeta.append(_exportAffiliations(jats, doc));
 
-  // author-notes? // not supported yet
+  // author-notes*
+  const authorNotes = doc.resolve(['article', 'conflictOfInterests']);
+  if (authorNotes.length > 0) {
+    articleMeta.append(
+      $$('author-notes').append(
+        authorNotes.map(authorNote => {
+          return jatsExporter.convertNode(authorNote);
+        }),
+      ),
+    );
+  }
 
   // pub-date*,
   articleMeta.append(_exportDate($$, metadata, 'publishedDate', 'pub', 'pub-date'));
@@ -567,9 +577,9 @@ function _populateBack(jats, doc, jatsExporter) {
     )
   */
 
-  // NOTE: Conflicts of Interest are a specific type of footnote, we just handle them internally as a seperate entity,
-  //       hence here we need to combine both footnotes and COI-statements and write them out as a singular group.
-  const footnotes = [...doc.resolve(['article', 'footnotes']), ...doc.resolve(['article', 'conflictOfInterests'])];
+  // FIXME: Seems at the moment footnotes are written into a single group, hence when loaded any group information will
+  //        be lost!
+  const footnotes = doc.resolve(['article', 'footnotes']);
   if (footnotes.length > 0) {
     backEl.append(
       $$('fn-group').append(

--- a/src/article/converter/jats/jats2internal.js
+++ b/src/article/converter/jats/jats2internal.js
@@ -21,6 +21,7 @@ export default function jats2internal(jats, doc, jatsImporter) {
   _populateAbstract(doc, jats, jatsImporter);
   _populateBody(doc, jats, jatsImporter);
   _populateFootnotes(doc, jats, jatsImporter);
+  _populateConflictOfInterests(doc, jats, jatsImporter);
   _populateReferences(doc, jats, jatsImporter);
   _populateAcknowledgements(doc, jats, jatsImporter);
 
@@ -492,9 +493,22 @@ function _populateBody(doc, jats, jatsImporter) {
 
 function _populateFootnotes(doc, jats, jatsImporter) {
   const $$ = jats.createElement.bind(jats);
-  const fnEls = jats.findAll('article > back > fn-group > fn');
+  const fnEls = jats.findAll('article > back > fn-group > fn:not([fn-type=COI-statement])');
   const article = doc.get('article');
   article.footnotes = fnEls.map(fnEl => {
+    // there must be at least one paragraph
+    if (!fnEl.find('p')) {
+      fnEl.append($$('p'));
+    }
+    return jatsImporter.convertElement(fnEl).id;
+  });
+}
+
+function _populateConflictOfInterests(doc, jats, jatsImporter) {
+  const $$ = jats.createElement.bind(jats);
+  const fnEls = jats.findAll('article > back > fn-group > fn[fn-type=COI-statement]');
+  const article = doc.get('article');
+  article.conflictOfInterests = fnEls.map(fnEl => {
     // there must be at least one paragraph
     if (!fnEl.find('p')) {
       fnEl.append($$('p'));

--- a/src/article/converter/jats/jats2internal.js
+++ b/src/article/converter/jats/jats2internal.js
@@ -103,7 +103,7 @@ function _populateContribs(doc, jats, importer, contribsPath, contribEls, groupI
         deceased: contribEl.getAttribute('deceased') === 'yes',
         group: groupId,
         contributorIds: _getContributorIds(contribEl, importer),
-        competingInterests: _getAuthorCompetingInterests(contribEl, importer),
+        conflictOfInterests: _getAuthorConflictOfInterests(contribEl, importer),
       });
       documentHelpers.append(doc, contribsPath, contrib.id);
     }
@@ -112,7 +112,7 @@ function _populateContribs(doc, jats, importer, contribsPath, contribEls, groupI
 
 function _populateAuthorNotes(doc, jats, jatsImporter) {
   const $$ = jats.createElement.bind(jats);
-  const fnEls = jats.findAll('article > front > article-meta > author-notes > fn');
+  const fnEls = jats.findAll('article > front > article-meta > author-notes > fn:not([fn-type=COI-statement])');
   const article = doc.get('article');
   article.authorNotes = fnEls.map(fnEl => {
     // there must be at least one paragraph
@@ -123,7 +123,7 @@ function _populateAuthorNotes(doc, jats, jatsImporter) {
   });
 }
 
-function _getAuthorCompetingInterests(el, importer) {
+function _getAuthorConflictOfInterests(el, importer) {
   const xrefs = el.findAll('xref[ref-type=fn]');
   const ids = xrefs.map(xref => xref.attr('rid'));
   return ids;
@@ -506,7 +506,10 @@ function _populateFootnotes(doc, jats, jatsImporter) {
 
 function _populateConflictOfInterests(doc, jats, jatsImporter) {
   const $$ = jats.createElement.bind(jats);
-  const fnEls = jats.findAll('article > back > fn-group > fn[fn-type=COI-statement]');
+  const fnEls = [
+    ...jats.findAll('article > front > article-meta > author-notes > fn[fn-type=COI-statement]'),
+    ...jats.findAll('article > back > fn-group > fn[fn-type=COI-statement]'),
+  ];
   const article = doc.get('article');
   article.conflictOfInterests = fnEls.map(fnEl => {
     // there must be at least one paragraph

--- a/src/article/nodes/Article.js
+++ b/src/article/nodes/Article.js
@@ -14,4 +14,5 @@ Article.schema = {
   relatedArticles: CHILDREN('related-article'),
   acknowledgements: CHILDREN('acknowledgement'),
   footnotes: CHILDREN('footnote'),
+  conflictOfInterests: CHILDREN('footnote'),
 };

--- a/src/article/nodes/Footnote.js
+++ b/src/article/nodes/Footnote.js
@@ -1,4 +1,4 @@
-import { DocumentNode, CONTAINER, PLAIN_TEXT } from 'substance';
+import { DocumentNode, CONTAINER, PLAIN_TEXT, STRING } from 'substance';
 
 export default class Footnote extends DocumentNode {
   static getTemplate() {
@@ -10,6 +10,7 @@ export default class Footnote extends DocumentNode {
 }
 Footnote.schema = {
   type: 'footnote',
+  footnoteType: STRING,
   label: PLAIN_TEXT,
   content: CONTAINER('paragraph'),
 };

--- a/src/article/nodes/Footnote.js
+++ b/src/article/nodes/Footnote.js
@@ -7,6 +7,19 @@ export default class Footnote extends DocumentNode {
       content: [{ type: 'paragraph' }],
     };
   }
+
+  render(options = {}) {
+    const doc = this.getDocument();
+    const content = [];
+    for (const id of this.content) {
+      content.push(doc.get(id).content);
+    }
+    return content;
+  }
+
+  toString() {
+    return this.render().join('. ');
+  }
 }
 Footnote.schema = {
   type: 'footnote',

--- a/src/article/nodes/Person.js
+++ b/src/article/nodes/Person.js
@@ -40,5 +40,5 @@ Person.schema = {
   corresp: BOOLEAN,
   deceased: BOOLEAN,
   contributorIds: CONTAINER('contributor-identifier'),
-  competingInterests: MANY('conflict-of-interest'),
+  conflictOfInterests: MANY('conflict-of-interest'),
 };

--- a/src/article/nodes/Person.js
+++ b/src/article/nodes/Person.js
@@ -8,11 +8,11 @@ export default class Person extends DocumentNode {
   // }
 
   render(options = {}) {
-    let { prefix, suffix, givenNames, surname } = this;
+    const { prefix, suffix, givenNames, surname } = this;
     if (options.short) {
       givenNames = extractInitials(givenNames);
     }
-    let result = [];
+    const result = [];
     if (prefix) {
       result.push(prefix, ' ');
     }
@@ -40,5 +40,5 @@ Person.schema = {
   corresp: BOOLEAN,
   deceased: BOOLEAN,
   contributorIds: CONTAINER('contributor-identifier'),
-  competingInterests: CONTAINER('footnote'),
+  competingInterests: MANY('footnote'),
 };

--- a/src/article/nodes/Person.js
+++ b/src/article/nodes/Person.js
@@ -40,5 +40,5 @@ Person.schema = {
   corresp: BOOLEAN,
   deceased: BOOLEAN,
   contributorIds: CONTAINER('contributor-identifier'),
-  competingInterests: MANY('footnote'),
+  competingInterests: MANY('conflict-of-interest'),
 };

--- a/src/article/shared/EntityLabelsPackage.js
+++ b/src/article/shared/EntityLabelsPackage.js
@@ -166,7 +166,7 @@ export default {
     config.addLabel('equalContrib', 'Equal Contribution');
     config.addLabel('corresp', 'Corresponding Author');
     config.addLabel('deceased', 'Deceased');
-    config.addLabel('conflictOfInterests', 'Conflict of Interest Statement');
+    config.addLabel('conflictOfInterests', 'Conflict of Interests');
 
     // affiliation labels
     config.addLabel('affiliation', 'Affiliation');

--- a/src/article/shared/EntityLabelsPackage.js
+++ b/src/article/shared/EntityLabelsPackage.js
@@ -166,6 +166,7 @@ export default {
     config.addLabel('equalContrib', 'Equal Contribution');
     config.addLabel('corresp', 'Corresponding Author');
     config.addLabel('deceased', 'Deceased');
+    config.addLabel('conflictOfInterests', 'Conflict of Interest Statement');
 
     // affiliation labels
     config.addLabel('affiliation', 'Affiliation');


### PR DESCRIPTION
## Why

Footnotes that are of the type 'coi-statement' are showing in the footnotes section, which should only display real footnotes.

## What

After trying a few different solutions, I now filter out 'coi-statements' during import into a separate property. I've also fixed the display of footnotes in the metadata view, although this will need changing again