### PR TITLE
fix: article info section should not be visible in metadata view

### DIFF
--- a/src/article/metadata/MetadataModel.js
+++ b/src/article/metadata/MetadataModel.js
@@ -10,7 +10,7 @@ export default class MetadataModel {
   constructor(api) {
     this._api = api;
     this._sections = [
-      { name: 'article-information', model: new ArticleInformationSectionModel(api) },
+      // { name: 'article-information', model: new ArticleInformationSectionModel(api) },
       { name: 'abstracts', model: new AbstractsSectionModel(api) },
       { name: 'authors', model: new AuthorsSectionModel(api) },
       { name: 'editors', model: createValueModel(api, ['metadata', 'editors']) },


### PR DESCRIPTION
## Why

Section is now displayed in article view, hence needs hiding...

## What

Removed it from the model
